### PR TITLE
chore: mark SkeletonPlaceholder as synced

### DIFF
--- a/.parity-check-data.json
+++ b/.parity-check-data.json
@@ -157,6 +157,7 @@
       "RadioGroup",
       "SearchInput",
       "Select",
+      "SkeletonPlaceholder",
       "Tabs",
       "Tag",
       "Theme",
@@ -252,7 +253,6 @@
       "SelectItemGroup",
       "ShapeIndicator",
       "SkeletonIcon",
-      "SkeletonPlaceholder",
       "SkeletonText",
       "Slider",
       "Stack",
@@ -423,6 +423,13 @@
       "lastUpdate": null
     },
     "Theme": {
+      "lastCheckedCommit": "5102bd860864c2580048183ffaf50d1ffd4400b5",
+      "lastSyncedCommit": "5102bd860864c2580048183ffaf50d1ffd4400b5",
+      "hasChanges": false,
+      "changeCount": 0,
+      "lastUpdate": null
+    },
+    "SkeletonPlaceholder": {
       "lastCheckedCommit": "5102bd860864c2580048183ffaf50d1ffd4400b5",
       "lastSyncedCommit": "5102bd860864c2580048183ffaf50d1ffd4400b5",
       "hasChanges": false,


### PR DESCRIPTION
## Summary

Parity investigation for **SkeletonPlaceholder** (#489): the component **already exists and fully matches React** — no code changes were needed. This PR only updates `.parity-check-data.json` so the parity check stops flagging it as missing.

## Details

- The React component ([source](https://github.com/carbon-design-system/carbon/tree/1110000e8374c35b7e040b09a7e292b2227f331d/packages/react/src/components/SkeletonPlaceholder)) renders a single `<div>` with the `cds--skeleton__placeholder` class and spreads remaining props; its only prop is `className`.
- The Ember implementation (`carbon-components-ember/src/components/skeleton-placeholder.gts`, added in #626) renders the same `<div class="cds--skeleton__placeholder" ...attributes>` — full parity, including class/attribute pass-through.
- Export, tests (`test-app/tests/components/skeleton-placeholder-test.gts`), and docs (`docs-app/public/docs/2-components/skeleton-placeholder.md`) are all in place.
- #626 didn't update the parity data, so the checker re-created issue #489. This moves `SkeletonPlaceholder` from `missing` to the ember list and records the synced commit (`5102bd8`), following the same pattern as the Theme PR (#642).

Closes #489

🤖 Generated with [Claude Code](https://claude.com/claude-code)