### PR TITLE
test: await settled() in OverflowMenu eventType regression test

### DIFF
--- a/test-app/tests/components/overflow-menu-test.gts
+++ b/test-app/tests/components/overflow-menu-test.gts
@@ -1,6 +1,6 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render, click } from '@ember/test-helpers';
+import { render, click, settled } from '@ember/test-helpers';
 import OverflowMenu from 'carbon-components-ember/components/overflow-menu';
 import { cell } from 'ember-resources';
 
@@ -86,6 +86,7 @@ module('Integration | Component | OverflowMenu', (hooks) => {
     trigger.dispatchEvent(
       new MouseEvent('mousedown', { bubbles: true, cancelable: true, button: 0 }),
     );
+    await settled();
 
     assert.dom('.cds--overflow-menu-options').exists();
   });


### PR DESCRIPTION
## Summary
- Small follow-up to #656 / #469: the `eventType='mousedown'` regression test added while addressing review feedback dispatched the event and asserted immediately, without awaiting `settled()`. That's flaky since the dropdown's open-state update isn't guaranteed to be synchronous.

## Test plan
- [x] `pnpm build` passes