### PR TITLE
chore: mark Popover as synced

### DIFF
--- a/.parity-check-data.json
+++ b/.parity-check-data.json
@@ -726,7 +726,7 @@
     },
     "Popover": {
       "lastCheckedCommit": "5102bd860864c2580048183ffaf50d1ffd4400b5",
-      "lastSyncedCommit": "5102bd860864c2580048183ffaf50d1ffd4400b5",
+      "lastSyncedCommit": "a57cf8a896fe3fe09c5ab27648cd58947f37360a",
       "hasChanges": false,
       "changeCount": 0,
       "lastUpdate": null


### PR DESCRIPTION
Closes #697 — verified Popover already matches the React implementation, no changes needed.

## Investigation

Compared the Ember `Popover`/`PopoverContent` (`carbon-components-ember/src/components/popover.gts`, implemented in #668) against Carbon React's `Popover` source (`packages/react/src/components/Popover/index.tsx`) and stories.

**Props** — every prop in React's `PopoverBaseProps` is present in Ember's `PopoverArgs`: `align` (including deprecated-value mapping), `alignmentAxisOffset` (documented as not implemented, since it only affects floating-ui's continuous positioning), `as`, `autoAlign`, `autoAlignBoundary`, `backgroundToken`, `border`, `caret`, `dropShadow`, `highContrast`, `isTabTip`, `onRequestClose`, `open`. `className`/`children` map naturally to Ember's `...attributes`/block content and don't need dedicated args.

**Stories** — `Default` (with caret/dropShadow/border/highContrast toggles), `TabTip`, and `ExperimentalAutoAlign` are each covered by their own live-preview example in `docs-app/public/docs/2-components/popover.md`. `autoAlign` is implemented as a documented lighter-weight approximation of React's floating-ui-based continuous repositioning (re-checks once on open rather than tracking continuously).

**Tests** — `test-app/tests/components/popover-test.gts` covers open/closed state, alignment mapping, caret/dropShadow/border/highContrast/backgroundToken classes, `isTabTip`, `as`, and the click-outside/click-inside/Escape-key close behaviors.

No code changes were required. This PR only updates `.parity-check-data.json` to mark `Popover` as synced at the current checked commit.

## Test plan
- [x] `pnpm build` succeeds
- [x] Existing popover test suite already covers the documented API