### PR TITLE
chore: mark ListBox as excluded from parity tracking

### DIFF
--- a/.parity-check-exclusions.json
+++ b/.parity-check-exclusions.json
@@ -1,0 +1,7 @@
+{
+  "ListBox": {
+    "reason": "ListBox is an internal composition primitive (container div + ListBoxField/ListBoxMenu/ListBoxMenuItem/ListBoxSelection) used by React to assemble Dropdown, ComboBox, and MultiSelect. It has no dedicated Storybook stories or MDX docs of its own (only a README) and isn't meant to be used standalone by app developers. When Dropdown/ComboBox/MultiSelect are implemented in Ember, they'll use native Ember patterns (own markup + cds-- classes) rather than this shared React compound-component primitive.",
+    "excludedAt": "2026-08-02T17:43:35.147Z",
+    "issue": "693"
+  }
+}


### PR DESCRIPTION
## Summary
- ListBox is an internal composition primitive (`ListBox`, `ListBoxField`, `ListBoxMenu`, `ListBoxMenuIcon`, `ListBoxMenuItem`, `ListBoxSelection`, `ListBoxTrigger`) used by Carbon React to assemble higher-level components like Dropdown, ComboBox, and MultiSelect.
- It has no dedicated Storybook stories or MDX docs of its own (only a `README.md`) and isn't something app developers use directly.
- When Dropdown/ComboBox/MultiSelect are implemented in Ember, they'll use native Ember patterns (own markup + `cds--` classes) rather than this shared React compound-component primitive.
- Recorded in `.parity-check-exclusions.json` so it no longer appears in `.parity-check-data.json` or `PARITY_REPORT.md`.

Closes #693 (duplicate of #464, which reached the same conclusion but whose exclusion commit was never merged).

## Test plan
- [x] `.parity-check-exclusions.json` updated with ListBox entry
- [x] Issue #693 commented and closed