### PR TITLE
fix: add autoAlign support to Tooltip

### DIFF
--- a/.parity-check-data.json
+++ b/.parity-check-data.json
@@ -565,7 +565,7 @@
     },
     "Tooltip": {
       "lastCheckedCommit": "5102bd860864c2580048183ffaf50d1ffd4400b5",
-      "lastSyncedCommit": "5102bd860864c2580048183ffaf50d1ffd4400b5",
+      "lastSyncedCommit": "a57cf8a896fe3fe09c5ab27648cd58947f37360a",
       "hasChanges": false,
       "changeCount": 0,
       "lastUpdate": null

--- a/carbon-components-ember/src/components/tooltip.gts
+++ b/carbon-components-ember/src/components/tooltip.gts
@@ -11,6 +11,8 @@ import { action } from '@ember/object';
 import { guidFor } from '@ember/object/internals';
 import { registerDestructor } from '@ember/destroyable';
 import { on } from '@ember/modifier';
+import didInsert from '@ember/render-modifiers/modifiers/did-insert';
+import didUpdate from '@ember/render-modifiers/modifiers/did-update';
 import { defaultArgs } from '../utils/decorators.ts';
 
 export const TooltipAlignments = [
@@ -38,6 +40,29 @@ export const TooltipAlignments = [
 
 export type TooltipAlignment = (typeof TooltipAlignments)[number];
 
+const flippedAlignmentMap: Record<TooltipAlignment, TooltipAlignment> = {
+  top: 'bottom',
+  'top-left': 'bottom-left',
+  'top-start': 'bottom-start',
+  'top-right': 'bottom-right',
+  'top-end': 'bottom-end',
+  bottom: 'top',
+  'bottom-left': 'top-left',
+  'bottom-start': 'top-start',
+  'bottom-right': 'top-right',
+  'bottom-end': 'top-end',
+  left: 'right',
+  'left-bottom': 'right-bottom',
+  'left-end': 'right-end',
+  'left-top': 'right-top',
+  'left-start': 'right-start',
+  right: 'left',
+  'right-bottom': 'left-bottom',
+  'right-end': 'left-end',
+  'right-top': 'left-top',
+  'right-start': 'left-start',
+};
+
 export type Args = {
   /** Where the tooltip is placed relative to the trigger */
   align?: TooltipAlignment;
@@ -45,6 +70,16 @@ export type Args = {
   label?: string;
   /** Description text for the trigger, announced via aria-describedby */
   description?: string;
+  /**
+   * Will auto-align the tooltip on open if it is not visible within the
+   * viewport (or `autoAlignBoundary`, if provided).
+   */
+  autoAlign?: boolean;
+  /**
+   * Specify a bounding element to be used for autoAlign calculations. The
+   * viewport is used by default.
+   */
+  autoAlignBoundary?: HTMLElement;
   /** Close the tooltip when the trigger is activated (click, Enter, Space) */
   closeOnActivation?: boolean;
   /** Render the tooltip open on initial render */
@@ -83,8 +118,10 @@ export default class CarbonTooltip extends Component<CarbonTooltipSignature> {
   };
 
   @tracked open = this.args.defaultOpen ?? false;
+  @tracked autoAlignResult: TooltipAlignment | null = null;
 
   timer?: ReturnType<typeof setTimeout>;
+  containerElement?: HTMLElement;
 
   constructor(owner: any, args: Args) {
     super(owner, args);
@@ -95,17 +132,65 @@ export default class CarbonTooltip extends Component<CarbonTooltipSignature> {
     return `${guidFor(this)}-tooltip`;
   }
 
+  get align(): TooltipAlignment {
+    return this.autoAlignResult ?? this.args.align ?? 'top';
+  }
+
   get classes() {
     const classes = [
       'cds--popover-container',
       'cds--popover--caret',
       'cds--tooltip',
-      `cds--popover--${this.args.align}`,
+      `cds--popover--${this.align}`,
     ];
     if (this.args.highContrast) classes.push('cds--popover--high-contrast');
     if (this.args.dropShadow) classes.push('cds--popover--drop-shadow');
     if (this.open) classes.push('cds--popover--open');
     return classes.join(' ');
+  }
+
+  @action
+  setup(el: HTMLElement) {
+    this.containerElement = el;
+    this.updateAutoAlign();
+  }
+
+  @action
+  update() {
+    this.updateAutoAlign();
+  }
+
+  updateAutoAlign() {
+    if (!this.args.autoAlign || !this.open || !this.containerElement) {
+      this.autoAlignResult = null;
+      return;
+    }
+
+    const content = this.containerElement.querySelector<HTMLElement>(
+      '.cds--popover-content',
+    );
+    if (!content) {
+      return;
+    }
+
+    const boundary = this.args.autoAlignBoundary;
+    const boundaryRect = boundary
+      ? boundary.getBoundingClientRect()
+      : { top: 0, left: 0, right: window.innerWidth, bottom: window.innerHeight };
+    const rect = content.getBoundingClientRect();
+
+    let align = this.args.align ?? 'top';
+    const overflowsVertically = rect.top < boundaryRect.top || rect.bottom > boundaryRect.bottom;
+    const overflowsHorizontally = rect.left < boundaryRect.left || rect.right > boundaryRect.right;
+
+    if (
+      ((align.startsWith('top') || align.startsWith('bottom')) && overflowsVertically) ||
+      ((align.startsWith('left') || align.startsWith('right')) && overflowsHorizontally)
+    ) {
+      align = flippedAlignmentMap[align] ?? align;
+    }
+
+    this.autoAlignResult = align;
   }
 
   setOpen(open: boolean, delayMs: number | undefined) {
@@ -164,6 +249,8 @@ export default class CarbonTooltip extends Component<CarbonTooltipSignature> {
     <span
       class={{this.classes}}
       ...attributes
+      {{didInsert this.setup}}
+      {{didUpdate this.update this.open this.args.align}}
       {{on 'mouseenter' this.onMouseEnter}}
       {{on 'mouseleave' this.onMouseLeave}}
       {{on 'focusin' this.onFocusIn}}

--- a/carbon-components-ember/src/components/tooltip.gts
+++ b/carbon-components-ember/src/components/tooltip.gts
@@ -250,7 +250,7 @@ export default class CarbonTooltip extends Component<CarbonTooltipSignature> {
       class={{this.classes}}
       ...attributes
       {{didInsert this.setup}}
-      {{didUpdate this.update this.open this.args.align}}
+      {{didUpdate this.update this.open @align}}
       {{on 'mouseenter' this.onMouseEnter}}
       {{on 'mouseleave' this.onMouseLeave}}
       {{on 'focusin' this.onFocusIn}}

--- a/docs-app/app/templates/2-components/tooltip.md
+++ b/docs-app/app/templates/2-components/tooltip.md
@@ -38,6 +38,62 @@ import { Tooltip, Button } from 'carbon-components-ember/components';
 </template>
 ```
 
+## Alignment
+
+`@align` controls which side of the trigger the tooltip is rendered on.
+
+```gjs live preview
+import { ThemeSupport } from 'docs-support';
+import { Tooltip, Button } from 'carbon-components-ember/components';
+<template>
+  <ThemeSupport />
+  <br>
+  <div style='display: flex; gap: 4rem; padding: 4rem 2rem;'>
+    <Tooltip @label='Tooltip alignment' @align='bottom-left'>
+      <Button @type='secondary'>This button has a tooltip</Button>
+    </Tooltip>
+  </div>
+</template>
+```
+
+## Duration
+
+`@enterDelayMs` and `@leaveDelayMs` control how long the tooltip waits
+before showing and hiding on hover.
+
+```gjs live preview
+import { ThemeSupport } from 'docs-support';
+import { Tooltip, Button } from 'carbon-components-ember/components';
+<template>
+  <ThemeSupport />
+  <br>
+  <div style='display: flex; gap: 4rem; padding: 4rem 2rem;'>
+    <Tooltip @label='Label one' @enterDelayMs={{0}} @leaveDelayMs={{300}}>
+      <Button @type='secondary'>This button has a tooltip</Button>
+    </Tooltip>
+  </div>
+</template>
+```
+
+## Auto align
+
+When `@autoAlign` is set, the tooltip flips to the opposite side if it
+would otherwise overflow the viewport (or `@autoAlignBoundary`, if
+provided).
+
+```gjs live preview
+import { ThemeSupport } from 'docs-support';
+import { Tooltip, Button } from 'carbon-components-ember/components';
+<template>
+  <ThemeSupport />
+  <br>
+  <div style='padding: 1rem 2rem 8rem;'>
+    <Tooltip @label='This tooltip flips to stay in the viewport' @align='top' @autoAlign={{true}}>
+      <Button @type='secondary'>Scroll me into view, near the bottom</Button>
+    </Tooltip>
+  </div>
+</template>
+```
 
 ## API Reference
 

--- a/test-app/tests/components/tooltip-test.gts
+++ b/test-app/tests/components/tooltip-test.gts
@@ -254,6 +254,72 @@ module('Integration | Component | Tooltip', (hooks) => {
     assert.dom('.cds--tooltip-content [data-custom]').hasText('Custom content');
   });
 
+  test('@autoAlign flips the alignment when the tooltip would overflow @autoAlignBoundary', async function (this: RenderingTestContext, assert) {
+    const styleValue = cell(carbonStyle.default);
+    // A fake boundary positioned far below the trigger guarantees the
+    // rendered tooltip content (which sits above the trigger for a 'top'
+    // alignment) overflows it, regardless of the trigger's real page
+    // position.
+    const boundary = {
+      getBoundingClientRect: () => ({
+        top: 10000,
+        left: 0,
+        right: 10000,
+        bottom: 20000,
+      }),
+    } as unknown as HTMLElement;
+
+    await render(
+      <template>
+        <style>{{styleValue.current}}</style>
+        <Tooltip
+          @label='Close'
+          @align='top'
+          @autoAlign={{true}}
+          @autoAlignBoundary={{boundary}}
+          @defaultOpen={{true}}
+        >
+          <button type='button'>Trigger</button>
+        </Tooltip>
+      </template>,
+    );
+    await waitForAnimationFrame();
+
+    await waitUntil(() =>
+      document
+        .querySelector('.cds--tooltip')!
+        .classList.contains('cds--popover--bottom'),
+    );
+    assert.dom('.cds--tooltip').hasClass('cds--popover--bottom');
+    assert.dom('.cds--tooltip').doesNotHaveClass('cds--popover--top');
+  });
+
+  test('without @autoAlign the alignment class does not flip', async function (assert) {
+    const boundary = {
+      getBoundingClientRect: () => ({
+        top: 10000,
+        left: 0,
+        right: 10000,
+        bottom: 20000,
+      }),
+    } as unknown as HTMLElement;
+
+    await render(
+      <template>
+        <Tooltip
+          @label='Close'
+          @align='top'
+          @autoAlignBoundary={{boundary}}
+          @defaultOpen={{true}}
+        >
+          <button type='button'>Trigger</button>
+        </Tooltip>
+      </template>,
+    );
+
+    assert.dom('.cds--tooltip').hasClass('cds--popover--top');
+  });
+
   test('passes through html attributes', async function (assert) {
     await render(
       <template>


### PR DESCRIPTION
## Summary
- `Tooltip` already existed in Ember with full parity for `align`, `label`, `description`, `closeOnActivation`, `defaultOpen`, `dropShadow`, `enterDelayMs`, `highContrast`, `leaveDelayMs`.
- Missing: React's `Tooltip` forwards `autoAlign`/`autoAlignBoundary` through to the underlying `Popover`, which flips the tooltip to the opposite side when it would overflow the viewport (used in 3 of the 4 React stories: `Default`, `ExperimentalAutoAlign`, `Duration`). The Ember `Popover` component already implements this exact flip logic, but `Tooltip` didn't expose it. Added matching `@autoAlign`/`@autoAlignBoundary` args to `Tooltip`, mirroring `Popover`'s flip-on-overflow behavior.
- Added docs examples for `Alignment`, `Duration`, and `Auto align`, covering all React stories.
- Added tests for the new autoAlign flip behavior.

## Test plan
- [x] `pnpm build` succeeds
- [x] `pnpm test -- --filter="Tooltip"` — 399 pass, 0 fail
- [x] Component marked synced in `.parity-check-data.json`

Closes #704