### PR TITLE
feat: add renderPageSelect and button tooltip position support to Pagination

### DIFF
--- a/.parity-check-data.json
+++ b/.parity-check-data.json
@@ -454,7 +454,7 @@
     },
     "Pagination": {
       "lastCheckedCommit": "5102bd860864c2580048183ffaf50d1ffd4400b5",
-      "lastSyncedCommit": "N/A",
+      "lastSyncedCommit": "a57cf8a896fe3fe09c5ab27648cd58947f37360a",
       "hasChanges": false,
       "changeCount": 0,
       "lastUpdate": null

--- a/carbon-components-ember/src/components/pagination.gts
+++ b/carbon-components-ember/src/components/pagination.gts
@@ -1,4 +1,5 @@
 import { default as Select } from './select.gts';
+import { default as Tooltip } from './tooltip.gts';
 import { default as defaultTo } from '../helpers/default-to.ts';
 import { default as eq } from 'ember-truth-helpers/helpers/eq';
 import { default as didInsert } from '@ember/render-modifiers/modifiers/did-insert';
@@ -14,7 +15,10 @@ import { stylesheet } from 'astroturf';
 import { runTask } from 'ember-lifeline';
 import { guidFor } from '@ember/object/internals';
 import { ChevronLeft, ChevronRight } from '../icons.ts';
+import type { ComponentLike } from '@glint/template';
 /** @documenter yuidoc */
+
+type TooltipPosition = 'top' | 'right' | 'bottom' | 'left';
 
 type Slice = {
   page: number;
@@ -35,6 +39,36 @@ export type Args = {
   onPageChanged: (currentSlice: Slice) => void;
   state?: State;
   itemsPerPageOptions?: (number | string)[];
+  /**
+   * The description for the backward icon, also used as its tooltip content.
+   */
+  backwardText?: string;
+  /**
+   * The tooltip position for the backward button.
+   */
+  backwardTextTooltipPosition?: TooltipPosition;
+  /**
+   * The description for the forward icon, also used as its tooltip content.
+   */
+  forwardText?: string;
+  /**
+   * The tooltip position for the forward button.
+   */
+  forwardTextTooltipPosition?: TooltipPosition;
+  /**
+   * Provide a custom component to render in place of the default page-select
+   * control. Receives `@currentPage`, `@totalPages`, `@currentPageSize`,
+   * `@pageSelectLabelText` and `@onSetPage`.
+   */
+  renderPageSelect?: ComponentLike<{
+    Args: {
+      currentPage: number;
+      totalPages: number;
+      currentPageSize: number;
+      pageSelectLabelText: string;
+      onSetPage: (page: number) => void;
+    };
+  }>;
 };
 
 export default class CarbonPagination extends Component<Args> {
@@ -47,10 +81,21 @@ export default class CarbonPagination extends Component<Args> {
     onPageChanged: () => null,
     state: undefined,
     itemsPerPageOptions: undefined,
+    backwardText: 'Previous page',
+    backwardTextTooltipPosition: 'top',
+    forwardText: 'Next page',
+    forwardTextTooltipPosition: 'top',
+    renderPageSelect: undefined,
   });
 
   get defaultArgs() {
     return this.args;
+  }
+
+  get pageSelectLabelText() {
+    return `Page ${this.currentPage} of ${this.pages} ${
+      this.pages === 1 ? 'page' : 'pages'
+    }`;
   }
 
   get pages() {
@@ -182,17 +227,27 @@ export default class CarbonPagination extends Component<Args> {
           </span>
         </div>
         <div class='cds--pagination__right'>
-        <div class="cds--form-item cds--select__item-count">
-          <Select
-            @inline={{true}}
-            @multiple={{false}}
-            @disabled={{@disabled}}
-            @searchEnabled={{false}}
-            @options={{range 1 this.pages true}}
-            @onSelect={{this.setCurrentPage}}
-            @selected={{this.currentPage}}
-          />
-        </div>
+          {{#if @renderPageSelect}}
+            <@renderPageSelect
+              @currentPage={{this.currentPage}}
+              @totalPages={{this.pages}}
+              @currentPageSize={{this.itemsPerPage}}
+              @pageSelectLabelText={{this.pageSelectLabelText}}
+              @onSetPage={{this.setCurrentPage}}
+            />
+          {{else}}
+            <div class="cds--form-item cds--select__item-count">
+              <Select
+                @inline={{true}}
+                @multiple={{false}}
+                @disabled={{@disabled}}
+                @searchEnabled={{false}}
+                @options={{range 1 this.pages true}}
+                @onSelect={{this.setCurrentPage}}
+                @selected={{this.currentPage}}
+              />
+            </div>
+          {{/if}}
           <label
             id='select-{{this.guid}}-pagination-page-label'
             class='cds--pagination__text'
@@ -203,28 +258,40 @@ export default class CarbonPagination extends Component<Args> {
             {{this.pages}}
             pages
           </label>
-          <button
-            disabled={{or (eq this.currentPage 1) @disabled}}
-            class='cds--btn--icon-only cds--pagination__button cds--pagination__button--backward cds--btn cds--btn--md cds--btn--ghost'
-            tabindex='0'
-            data-page-backward
-            aria-label='previous page'
-            type='button'
-            {{on 'click' this.pageBack}}
-          >
-            <ChevronLeft @btnClass='cds--pagination__nav-arrow' />
-          </button>
-          <button
-            disabled={{or (eq this.currentPage this.pages) @disabled}}
-            class='cds--btn--icon-only cds--pagination__button cds--pagination__button--forward cds--btn cds--btn--md cds--btn--ghost'
-            tabindex='0'
-            data-page-forward
-            aria-label='next page'
-            type='button'
-            {{on 'click' this.pageForward}}
-          >
-            <ChevronRight @btnClass="cds--pagination__nav-arrow" />
-          </button>
+          <div class='cds--pagination__control-buttons'>
+            <Tooltip
+              @align={{this.defaultArgs.backwardTextTooltipPosition}}
+              @label={{this.defaultArgs.backwardText}}
+            >
+              <button
+                disabled={{or (eq this.currentPage 1) @disabled}}
+                class='cds--btn--icon-only cds--pagination__button cds--pagination__button--backward cds--btn cds--btn--md cds--btn--ghost'
+                tabindex='0'
+                data-page-backward
+                aria-label={{this.defaultArgs.backwardText}}
+                type='button'
+                {{on 'click' this.pageBack}}
+              >
+                <ChevronLeft @btnClass='cds--pagination__nav-arrow' />
+              </button>
+            </Tooltip>
+            <Tooltip
+              @align={{this.defaultArgs.forwardTextTooltipPosition}}
+              @label={{this.defaultArgs.forwardText}}
+            >
+              <button
+                disabled={{or (eq this.currentPage this.pages) @disabled}}
+                class='cds--btn--icon-only cds--pagination__button cds--pagination__button--forward cds--btn cds--btn--md cds--btn--ghost'
+                tabindex='0'
+                data-page-forward
+                aria-label={{this.defaultArgs.forwardText}}
+                type='button'
+                {{on 'click' this.pageForward}}
+              >
+                <ChevronRight @btnClass="cds--pagination__nav-arrow" />
+              </button>
+            </Tooltip>
+          </div>
         </div>
       {{/if}}
     </div>

--- a/carbon-components-ember/src/components/pagination.gts
+++ b/carbon-components-ember/src/components/pagination.gts
@@ -1,4 +1,5 @@
 import { default as Select } from './select.gts';
+import { default as Tooltip } from './tooltip.gts';
 import { default as defaultTo } from '../helpers/default-to.ts';
 import { default as eq } from 'ember-truth-helpers/helpers/eq';
 import { default as didInsert } from '@ember/render-modifiers/modifiers/did-insert';
@@ -14,7 +15,10 @@ import { stylesheet } from 'astroturf';
 import { runTask } from 'ember-lifeline';
 import { guidFor } from '@ember/object/internals';
 import { ChevronLeft, ChevronRight } from '../icons.ts';
+import type { ComponentLike } from '@glint/template';
 /** @documenter yuidoc */
+
+type TooltipPosition = 'top' | 'right' | 'bottom' | 'left';
 
 type Slice = {
   page: number;
@@ -36,6 +40,36 @@ export type Args = {
   state?: State;
   itemsPerPageOptions?: (number | string)[];
   size?: 'xs' | 'sm' | 'md' | 'lg';
+  /**
+   * The description for the backward icon, also used as its tooltip content.
+   */
+  backwardText?: string;
+  /**
+   * The tooltip position for the backward button.
+   */
+  backwardTextTooltipPosition?: TooltipPosition;
+  /**
+   * The description for the forward icon, also used as its tooltip content.
+   */
+  forwardText?: string;
+  /**
+   * The tooltip position for the forward button.
+   */
+  forwardTextTooltipPosition?: TooltipPosition;
+  /**
+   * Provide a custom component to render in place of the default page-select
+   * control. Receives `@currentPage`, `@totalPages`, `@currentPageSize`,
+   * `@pageSelectLabelText` and `@onSetPage`.
+   */
+  renderPageSelect?: ComponentLike<{
+    Args: {
+      currentPage: number;
+      totalPages: number;
+      currentPageSize: number;
+      pageSelectLabelText: string;
+      onSetPage: (page: number) => void;
+    };
+  }>;
 };
 
 export default class CarbonPagination extends Component<Args> {
@@ -49,10 +83,21 @@ export default class CarbonPagination extends Component<Args> {
     state: undefined,
     itemsPerPageOptions: undefined,
     size: 'md',
+    backwardText: 'Previous page',
+    backwardTextTooltipPosition: 'top',
+    forwardText: 'Next page',
+    forwardTextTooltipPosition: 'top',
+    renderPageSelect: undefined,
   });
 
   get defaultArgs() {
     return this.args;
+  }
+
+  get pageSelectLabelText() {
+    return `Page ${this.currentPage} of ${this.pages} ${
+      this.pages === 1 ? 'page' : 'pages'
+    }`;
   }
 
   get pages() {
@@ -184,17 +229,27 @@ export default class CarbonPagination extends Component<Args> {
           </span>
         </div>
         <div class='cds--pagination__right'>
-        <div class="cds--form-item cds--select__item-count">
-          <Select
-            @inline={{true}}
-            @multiple={{false}}
-            @disabled={{@disabled}}
-            @searchEnabled={{false}}
-            @options={{range 1 this.pages true}}
-            @onSelect={{this.setCurrentPage}}
-            @selected={{this.currentPage}}
-          />
-        </div>
+          {{#if @renderPageSelect}}
+            <@renderPageSelect
+              @currentPage={{this.currentPage}}
+              @totalPages={{this.pages}}
+              @currentPageSize={{this.itemsPerPage}}
+              @pageSelectLabelText={{this.pageSelectLabelText}}
+              @onSetPage={{this.setCurrentPage}}
+            />
+          {{else}}
+            <div class="cds--form-item cds--select__item-count">
+              <Select
+                @inline={{true}}
+                @multiple={{false}}
+                @disabled={{@disabled}}
+                @searchEnabled={{false}}
+                @options={{range 1 this.pages true}}
+                @onSelect={{this.setCurrentPage}}
+                @selected={{this.currentPage}}
+              />
+            </div>
+          {{/if}}
           <label
             id='select-{{this.guid}}-pagination-page-label'
             class='cds--pagination__text'
@@ -205,28 +260,40 @@ export default class CarbonPagination extends Component<Args> {
             {{this.pages}}
             pages
           </label>
-          <button
-            disabled={{or (eq this.currentPage 1) @disabled}}
-            class='cds--btn--icon-only cds--pagination__button cds--pagination__button--backward cds--btn cds--btn--md cds--btn--ghost'
-            tabindex='0'
-            data-page-backward
-            aria-label='previous page'
-            type='button'
-            {{on 'click' this.pageBack}}
-          >
-            <ChevronLeft @btnClass='cds--pagination__nav-arrow' />
-          </button>
-          <button
-            disabled={{or (eq this.currentPage this.pages) @disabled}}
-            class='cds--btn--icon-only cds--pagination__button cds--pagination__button--forward cds--btn cds--btn--md cds--btn--ghost'
-            tabindex='0'
-            data-page-forward
-            aria-label='next page'
-            type='button'
-            {{on 'click' this.pageForward}}
-          >
-            <ChevronRight @btnClass="cds--pagination__nav-arrow" />
-          </button>
+          <div class='cds--pagination__control-buttons'>
+            <Tooltip
+              @align={{this.defaultArgs.backwardTextTooltipPosition}}
+              @label={{this.defaultArgs.backwardText}}
+            >
+              <button
+                disabled={{or (eq this.currentPage 1) @disabled}}
+                class='cds--btn--icon-only cds--pagination__button cds--pagination__button--backward cds--btn cds--btn--md cds--btn--ghost'
+                tabindex='0'
+                data-page-backward
+                aria-label={{this.defaultArgs.backwardText}}
+                type='button'
+                {{on 'click' this.pageBack}}
+              >
+                <ChevronLeft @btnClass='cds--pagination__nav-arrow' />
+              </button>
+            </Tooltip>
+            <Tooltip
+              @align={{this.defaultArgs.forwardTextTooltipPosition}}
+              @label={{this.defaultArgs.forwardText}}
+            >
+              <button
+                disabled={{or (eq this.currentPage this.pages) @disabled}}
+                class='cds--btn--icon-only cds--pagination__button cds--pagination__button--forward cds--btn cds--btn--md cds--btn--ghost'
+                tabindex='0'
+                data-page-forward
+                aria-label={{this.defaultArgs.forwardText}}
+                type='button'
+                {{on 'click' this.pageForward}}
+              >
+                <ChevronRight @btnClass="cds--pagination__nav-arrow" />
+              </button>
+            </Tooltip>
+          </div>
         </div>
       {{/if}}
     </div>

--- a/carbon-components-ember/src/components/tooltip.gts
+++ b/carbon-components-ember/src/components/tooltip.gts
@@ -14,7 +14,7 @@ import { on } from '@ember/modifier';
 import didInsert from '@ember/render-modifiers/modifiers/did-insert';
 import didUpdate from '@ember/render-modifiers/modifiers/did-update';
 import { defaultArgs } from '../utils/decorators.ts';
-import { schedule } from '@ember/runloop';
+import { scheduleTask } from 'ember-lifeline';
 
 export const TooltipAlignments = [
   'top',
@@ -221,20 +221,16 @@ export default class CarbonTooltip extends Component<CarbonTooltipSignature> {
     // `disabled`, which browsers blur automatically), which can happen while
     // Glimmer is still mid-render. Setting a tracked property directly in
     // that window trips the "already used in this computation" assertion.
-    schedule('actions', () => {
-      if (!this.isDestroying) {
-        this.open = true;
-      }
+    scheduleTask(this, 'actions', () => {
+      this.open = true;
     });
   }
 
   @action
   onFocusOut() {
     clearTimeout(this.timer);
-    schedule('actions', () => {
-      if (!this.isDestroying) {
-        this.open = false;
-      }
+    scheduleTask(this, 'actions', () => {
+      this.open = false;
     });
   }
 

--- a/carbon-components-ember/src/components/tooltip.gts
+++ b/carbon-components-ember/src/components/tooltip.gts
@@ -14,6 +14,7 @@ import { on } from '@ember/modifier';
 import didInsert from '@ember/render-modifiers/modifiers/did-insert';
 import didUpdate from '@ember/render-modifiers/modifiers/did-update';
 import { defaultArgs } from '../utils/decorators.ts';
+import { schedule } from '@ember/runloop';
 
 export const TooltipAlignments = [
   'top',
@@ -215,13 +216,26 @@ export default class CarbonTooltip extends Component<CarbonTooltipSignature> {
   @action
   onFocusIn() {
     clearTimeout(this.timer);
-    this.open = true;
+    // Deferred via the runloop: a focusin/focusout can fire synchronously as
+    // a side effect of a DOM mutation (e.g. a focused trigger becoming
+    // `disabled`, which browsers blur automatically), which can happen while
+    // Glimmer is still mid-render. Setting a tracked property directly in
+    // that window trips the "already used in this computation" assertion.
+    schedule('actions', () => {
+      if (!this.isDestroying) {
+        this.open = true;
+      }
+    });
   }
 
   @action
   onFocusOut() {
     clearTimeout(this.timer);
-    this.open = false;
+    schedule('actions', () => {
+      if (!this.isDestroying) {
+        this.open = false;
+      }
+    });
   }
 
   @action

--- a/docs-app/app/templates/2-components/pagination.md
+++ b/docs-app/app/templates/2-components/pagination.md
@@ -63,6 +63,65 @@ const not = (x) => !x;
 </template>
 ```
 
+## Customizing the navigation button text and tooltips
+
+Use `@backwardText`/`@forwardText` to customize the accessible label and
+tooltip content of the navigation buttons, and
+`@backwardTextTooltipPosition`/`@forwardTextTooltipPosition` to control where
+the tooltip is placed.
+
+```gjs live preview
+import { Pagination } from 'carbon-components-ember/components';
+import { ThemeSupport } from 'docs-support';
+
+const noop = () => null;
+
+<template>
+    <ThemeSupport />
+    <Pagination
+        @length={{50}}
+        @onPageChanged={{noop}}
+        @backwardText='Prior page'
+        @forwardText='Later page'
+        @backwardTextTooltipPosition='bottom'
+        @forwardTextTooltipPosition='bottom'
+    />
+</template>
+```
+
+## Custom page-selection control
+
+Use `@renderPageSelect` to replace the default page-select control with a
+custom component. It receives `@currentPage`, `@totalPages`,
+`@currentPageSize`, `@pageSelectLabelText` and `@onSetPage`.
+
+```gjs live preview
+import { Pagination } from 'carbon-components-ember/components';
+import { ThemeSupport } from 'docs-support';
+import { on } from '@ember/modifier';
+import { fn } from '@ember/helper';
+
+const noop = () => null;
+
+const CustomPageSelect = <template>
+    <span aria-label={{@pageSelectLabelText}}>
+        Page
+        <button type='button' {{on 'click' (fn @onSetPage 1)}}>1</button>
+        of
+        {{@totalPages}}
+    </span>
+</template>;
+
+<template>
+    <ThemeSupport />
+    <Pagination
+        @length={{100}}
+        @onPageChanged={{noop}}
+        @renderPageSelect={{CustomPageSelect}}
+    />
+</template>
+```
+
 ## API Reference
 
 <details>

--- a/docs-app/app/templates/2-components/pagination.md
+++ b/docs-app/app/templates/2-components/pagination.md
@@ -81,6 +81,65 @@ import { ThemeSupport } from 'docs-support';
 
 </details>
 
+## Customizing the navigation button text and tooltips
+
+Use `@backwardText`/`@forwardText` to customize the accessible label and
+tooltip content of the navigation buttons, and
+`@backwardTextTooltipPosition`/`@forwardTextTooltipPosition` to control where
+the tooltip is placed.
+
+```gjs live preview
+import { Pagination } from 'carbon-components-ember/components';
+import { ThemeSupport } from 'docs-support';
+
+const noop = () => null;
+
+<template>
+    <ThemeSupport />
+    <Pagination
+        @length={{50}}
+        @onPageChanged={{noop}}
+        @backwardText='Prior page'
+        @forwardText='Later page'
+        @backwardTextTooltipPosition='bottom'
+        @forwardTextTooltipPosition='bottom'
+    />
+</template>
+```
+
+## Custom page-selection control
+
+Use `@renderPageSelect` to replace the default page-select control with a
+custom component. It receives `@currentPage`, `@totalPages`,
+`@currentPageSize`, `@pageSelectLabelText` and `@onSetPage`.
+
+```gjs live preview
+import { Pagination } from 'carbon-components-ember/components';
+import { ThemeSupport } from 'docs-support';
+import { on } from '@ember/modifier';
+import { fn } from '@ember/helper';
+
+const noop = () => null;
+
+const CustomPageSelect = <template>
+    <span aria-label={{@pageSelectLabelText}}>
+        Page
+        <button type='button' {{on 'click' (fn @onSetPage 1)}}>1</button>
+        of
+        {{@totalPages}}
+    </span>
+</template>;
+
+<template>
+    <ThemeSupport />
+    <Pagination
+        @length={{100}}
+        @onPageChanged={{noop}}
+        @renderPageSelect={{CustomPageSelect}}
+    />
+</template>
+```
+
 ## API Reference
 
 <details>

--- a/test-app/tests/components/pagination-test.gts
+++ b/test-app/tests/components/pagination-test.gts
@@ -1,0 +1,160 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render, click } from '@ember/test-helpers';
+import Pagination from 'carbon-components-ember/components/pagination';
+import { on } from '@ember/modifier';
+import { fn } from '@ember/helper';
+import type { TOC } from '@ember/component/template-only';
+
+const noop = () => null;
+
+module('Integration | Component | Pagination', (hooks) => {
+  setupRenderingTest(hooks);
+
+  test('should render with default items per page and page count', async function (assert) {
+    await render(
+      <template>
+        <Pagination @length={{25}} @onPageChanged={{noop}} />
+      </template>,
+    );
+
+    assert.dom('[data-pagination]').exists();
+    assert.dom('[data-total-items]').hasText('25');
+    assert.dom('[data-displayed-item-range]').hasText('0 - 10');
+  });
+
+  test('backward/forward buttons default to "Previous page"/"Next page" as aria-label and tooltip content', async function (assert) {
+    await render(
+      <template>
+        <Pagination @length={{25}} @onPageChanged={{noop}} />
+      </template>,
+    );
+
+    assert
+      .dom('[data-page-backward]')
+      .hasAttribute('aria-label', 'Previous page');
+    assert.dom('[data-page-forward]').hasAttribute('aria-label', 'Next page');
+
+    const tooltipContents = document.querySelectorAll('.cds--tooltip-content');
+    assert.strictEqual(tooltipContents[0]?.textContent?.trim(), 'Previous page');
+    assert.strictEqual(tooltipContents[1]?.textContent?.trim(), 'Next page');
+  });
+
+  test('@backwardText/@forwardText customize the aria-label and tooltip content', async function (assert) {
+    await render(
+      <template>
+        <Pagination
+          @length={{25}}
+          @onPageChanged={{noop}}
+          @backwardText='Prior'
+          @forwardText='Later'
+        />
+      </template>,
+    );
+
+    assert.dom('[data-page-backward]').hasAttribute('aria-label', 'Prior');
+    assert.dom('[data-page-forward]').hasAttribute('aria-label', 'Later');
+
+    const tooltipContents = document.querySelectorAll('.cds--tooltip-content');
+    assert.strictEqual(tooltipContents[0]?.textContent?.trim(), 'Prior');
+    assert.strictEqual(tooltipContents[1]?.textContent?.trim(), 'Later');
+  });
+
+  test('@backwardTextTooltipPosition/@forwardTextTooltipPosition set the tooltip alignment', async function (assert) {
+    await render(
+      <template>
+        <Pagination
+          @length={{25}}
+          @onPageChanged={{noop}}
+          @backwardTextTooltipPosition='left'
+          @forwardTextTooltipPosition='right'
+        />
+      </template>,
+    );
+
+    const tooltips = document.querySelectorAll('.cds--tooltip');
+    assert.dom(tooltips[0] as HTMLElement).hasClass('cds--popover--left');
+    assert.dom(tooltips[1] as HTMLElement).hasClass('cds--popover--right');
+  });
+
+  test('clicking forward/backward changes the current page', async function (assert) {
+    const onPageChanged = (slice: { page: number }) => {
+      assert.step(`page-${slice.page}`);
+    };
+
+    await render(
+      <template>
+        <Pagination @length={{25}} @onPageChanged={{onPageChanged}} />
+      </template>,
+    );
+
+    assert.dom('[data-page-backward]').isDisabled();
+
+    await click('[data-page-forward]');
+
+    assert.dom('[data-displayed-item-range]').hasText('10 - 20');
+    assert.dom('[data-page-backward]').isNotDisabled();
+
+    await click('[data-page-backward]');
+
+    assert.dom('[data-displayed-item-range]').hasText('0 - 10');
+    assert.verifySteps(['page-1', 'page-2', 'page-1']);
+  });
+
+  test('@disabled disables the navigation buttons', async function (assert) {
+    await render(
+      <template>
+        <Pagination
+          @length={{25}}
+          @onPageChanged={{noop}}
+          @disabled={{true}}
+        />
+      </template>,
+    );
+
+    assert.dom('[data-page-forward]').isDisabled();
+    assert.dom('[data-page-backward]').isDisabled();
+  });
+
+  test('@renderPageSelect renders a custom page-selection control instead of the default select', async function (assert) {
+    const CustomPageSelect: TOC<{
+      Args: {
+        currentPage: number;
+        totalPages: number;
+        currentPageSize: number;
+        pageSelectLabelText: string;
+        onSetPage: (page: number) => void;
+      };
+    }> = <template>
+      <button
+        type='button'
+        data-custom-page-select
+        {{! template-lint-disable require-button-type }}
+        aria-label={{@pageSelectLabelText}}
+        {{on 'click' (fn @onSetPage 3)}}
+      >
+        {{@currentPage}}/{{@totalPages}}
+      </button>
+    </template>;
+
+    await render(
+      <template>
+        <Pagination
+          @length={{100}}
+          @onPageChanged={{noop}}
+          @renderPageSelect={{CustomPageSelect}}
+        />
+      </template>,
+    );
+
+    assert.dom('[data-custom-page-select]').exists();
+    assert.dom('[data-custom-page-select]').hasText('1/11');
+    assert
+      .dom('.cds--pagination__right .cds--select__item-count')
+      .doesNotExist();
+
+    await click('[data-custom-page-select]');
+
+    assert.dom('[data-custom-page-select]').hasText('3/11');
+  });
+});


### PR DESCRIPTION
Closes #713

## Summary

Brings Ember's `Pagination` in sync with the React changes since the last parity check (up to `a57cf8a`):

- **`@renderPageSelect`** — optional component reference that replaces the default page-select control in `cds--pagination__right`. Receives `@currentPage`, `@totalPages`, `@currentPageSize`, `@pageSelectLabelText`, `@onSetPage`, mirroring React's `renderPageSelect` render prop (carbon-design-system/carbon#22617).
- **`@backwardTextTooltipPosition` / `@forwardTextTooltipPosition`** — the previous/next buttons are now wrapped in the `Tooltip` component with a configurable `@align`, matching React's per-button tooltip position (carbon-design-system/carbon#22199).
- **`@backwardText` / `@forwardText`** — new args to customize the aria-label and tooltip content of the nav buttons (default to `"Previous page"`/`"Next page"`, matching React's defaults). Previously these were hardcoded, lowercase, and not configurable.

The other two upstream commits (`c0980c4`, `51dab56`) only touched Storybook controls/VRT stories and have no component-level impact.

### Fix in `Tooltip`

Wrapping the nav buttons (whose `disabled` state toggles as a *result* of clicking them) in `Tooltip` surfaced a latent bug: when a focused, just-clicked button becomes `disabled`, the browser blurs it synchronously mid-render, and `Tooltip`'s `onFocusIn`/`onFocusOut` were setting the tracked `open` property directly in that window — tripping Ember's "already used in this computation" assertion. Both handlers now defer the update through the runloop's `actions` queue, which doesn't change any existing `Tooltip` test's observable behavior (all existing Tooltip tests still pass) but avoids the crash.

## Test plan

- [x] `pnpm build` succeeds
- [x] New `pagination-test.gts` covers default rendering, `@backwardText`/`@forwardText`, tooltip position, click navigation, `@disabled`, and `@renderPageSelect`
- [x] Full `test-app` suite passes (407/407), including all `Tooltip` tests (no regression from the runloop fix)
- [x] Added two live-preview docs examples (tooltip position/text customization, custom `@renderPageSelect`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)