### PR TITLE
chore: mark Switch as excluded from parity tracking

### DIFF
--- a/.parity-check-exclusions.json
+++ b/.parity-check-exclusions.json
@@ -3,5 +3,10 @@
     "reason": "ListBox is an internal composition primitive (container div + ListBoxField/ListBoxMenu/ListBoxMenuItem/ListBoxSelection) used by React to assemble Dropdown, ComboBox, and MultiSelect. It has no dedicated Storybook stories or MDX docs of its own (only a README) and isn't meant to be used standalone by app developers. When Dropdown/ComboBox/MultiSelect are implemented in Ember, they'll use native Ember patterns (own markup + cds-- classes) rather than this shared React compound-component primitive.",
     "excludedAt": "2026-08-02T17:43:35.147Z",
     "issue": "693"
+  },
+  "Switch": {
+    "reason": "Switch/IconSwitch in Carbon React are internal building-block components explicitly documented in the source as \"Reserved for usage in ContentSwitcher\" — they render as the tab-like buttons that are children of ContentSwitcher, with no standalone Storybook page or independent public API. ContentSwitcher itself is not yet implemented in this Ember addon; when it is, this switch-item rendering will be built as an internal part of that component rather than exposed as a separate public export. This duplicates the investigation already done in issue #494 (closed wontfix), whose exclusion commit never made it into main.",
+    "excludedAt": "2026-08-04T09:14:48.584Z",
+    "issue": "701"
   }
 }


### PR DESCRIPTION
## Summary

- `Switch`/`IconSwitch` in Carbon React are internal building-block components explicitly documented as "Reserved for usage in `ContentSwitcher`" — the tab-like buttons rendered as children of `ContentSwitcher`. There's no standalone Storybook page or independent public API for them.
- `ContentSwitcher` itself isn't implemented in this Ember addon yet; when it is, this switch-item rendering will be an internal part of that component rather than a separate public export.
- This duplicates the investigation already done in #494 (closed wontfix by @patricklx) — that exclusion (`exclude-switch-494` branch) was never merged into `main`, which is why the parity-check script regenerated a duplicate issue (#701). Same fix pattern as PR #724 for the ListBox exclusion.

Closes #701

## Test plan

- [x] Ran `node scripts/parity-check.mjs --exclude Switch --reason "..." --issue 701` to record the exclusion in `.parity-check-exclusions.json`
- [x] Commented on and closed #701 manually (the script's GitHub API calls only run in CI with `GITHUB_REPOSITORY` set)