### PR TITLE
chore: mark Tab as excluded from parity tracking

### DIFF
--- a/.parity-check-exclusions.json
+++ b/.parity-check-exclusions.json
@@ -13,5 +13,10 @@
     "reason": "React SecondaryButton is a thin wrapper (<Button kind=\"secondary\" {...props} />) with no distinct props/stories; fully covered by the existing Ember Button component's @type='secondary' argument",
     "excludedAt": "2026-08-04T09:24:30.880Z",
     "issue": "699"
+  },
+  "Tab": {
+    "reason": "Tab is not a standalone React component — its source (packages/react/src/components/Tab/index.tsx) simply re-exports the Tab sub-component from Tabs/Tabs.tsx. It only exists as a child of Tabs > TabList and has no standalone usage. This functionality is already covered by the existing Ember Tabs component (src/components/tabs.gts), which is tracked and implemented separately.",
+    "excludedAt": "2026-08-04T09:45:17.206Z",
+    "issue": "702"
   }
 }


### PR DESCRIPTION
Closes #702

## Summary
- React's `Tab` (`packages/react/src/components/Tab/index.tsx`) is not a standalone component — it re-exports the `Tab` sub-component from `Tabs/Tabs.tsx` and only functions as a child of `Tabs > TabList`.
- The nav-item/button behavior it provides (ARIA attributes, selected/disabled states, click handling) is already implemented inline by Ember's `Tabs` component (`src/components/tabs.gts`), which is tracked and marked `implemented` in parity data separately.
- An earlier exclusion for this exact reasoning (issue #495, commit 199f5b4e) was never merged to `main`, so the parity-check automation regenerated a duplicate issue (#702). This PR lands the exclusion for real.

## Test plan
- [x] `node parity-check.mjs --exclude Tab --reason ... --issue 702` recorded the exclusion in `.parity-check-exclusions.json`
- [x] Issue #702 commented and closed (manually, since `GITHUB_TOKEN`/`GITHUB_REPOSITORY` aren't set in this environment)