### PR TITLE
fix: support xs size on PasswordInput

### DIFF
--- a/.parity-check-data.json
+++ b/.parity-check-data.json
@@ -335,7 +335,7 @@
   "componentMetadata": {
     "PasswordInput": {
       "lastCheckedCommit": "5102bd860864c2580048183ffaf50d1ffd4400b5",
-      "lastSyncedCommit": "5102bd860864c2580048183ffaf50d1ffd4400b5",
+      "lastSyncedCommit": "a57cf8a896fe3fe09c5ab27648cd58947f37360a",
       "hasChanges": false,
       "changeCount": 0,
       "lastUpdate": null

--- a/carbon-components-ember/src/components/password-input.gts
+++ b/carbon-components-ember/src/components/password-input.gts
@@ -24,7 +24,7 @@ export interface Signature {
     defaultValue?: string;
     placeholder?: string;
     type?: 'password' | 'text';
-    size?: 'sm' | 'md' | 'lg';
+    size?: 'xs' | 'sm' | 'md' | 'lg';
     disabled?: boolean;
     readOnly?: boolean;
     inline?: boolean;

--- a/docs-app/app/templates/2-components/password-input.md
+++ b/docs-app/app/templates/2-components/password-input.md
@@ -24,6 +24,8 @@ const update = (value) => {
     <br/>
     value: {{context.value}}
     <br />
+    <PasswordInput @labelText="Extra small" @size="xs" />
+    <br />
     <PasswordInput @labelText="Small" @size="sm" />
     <br />
     <PasswordInput @labelText="Large" @size="lg" />

--- a/test-app/tests/components/password-input-test.gts
+++ b/test-app/tests/components/password-input-test.gts
@@ -37,6 +37,12 @@ module('Integration | Component | PasswordInput', (hooks) => {
     assert.dom('.cds--text-input-wrapper').hasClass('cds--layout--size-sm');
   });
 
+  test('should support the xs layout size', async function (assert) {
+    await render(<template><PasswordInput @size='xs' /></template>);
+
+    assert.dom('.cds--text-input-wrapper').hasClass('cds--layout--size-xs');
+  });
+
   test('should respect the disabled and readOnly arguments', async function (assert) {
     await render(
       <template><PasswordInput @disabled={{true}} @readOnly={{true}} /></template>,


### PR DESCRIPTION
## Summary
- Investigated #682's report that "the controlled input is not updating the value" in the docs app for `PasswordInput`. Could not reproduce at the component level — isolated rendering tests (both `fillIn` and keystroke-by-keystroke `typeIn`) confirm the controlled `@value`/`@onChange` binding works correctly, matching the docs page's pattern exactly. Details in the issue comment.
- While doing the full API parity pass, found and fixed a real gap: `size` only accepted `'sm' | 'md' | 'lg'`, but Carbon React's `PasswordInput` (and the underlying `@carbon/styles` text-input SCSS via `layout.use('size', $min: 'xs', $max: 'lg')`) also supports `'xs'`.
- Added an `xs` docs example and a test.

Closes #682

## Test plan
- [x] `pnpm build` succeeds
- [x] `PasswordInput` integration tests pass, including new `xs` size test
- [x] Manually reasoned through controlled-value binding with isolated fillIn/typeIn tests