### PR TITLE
fix: retry gh-pages push on race with concurrent PR preview deploys

### DIFF
--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -55,14 +55,30 @@ jobs:
 
       - name: Deploy to gh-pages
         run: |
-          mkdir -p $GITHUB_WORKSPACE/gh-pages/pr-previews/pr-${{ github.event.pull_request.number }}
-          cp -r ./docs-app/dist/* $GITHUB_WORKSPACE/gh-pages/pr-previews/pr-${{ github.event.pull_request.number }}/
           cd $GITHUB_WORKSPACE/gh-pages
           git config --global user.name 'Patrick Pircher'
           git config --global user.email 'patricklx@users.noreply.github.com'
-          git add .
-          git diff --staged --quiet || git commit -m "Deploy docs preview for PR #${{ github.event.pull_request.number }} (${{ github.event.pull_request.head.sha }})"
-          git push
+          for i in 1 2 3 4 5; do
+            rm -rf pr-previews/pr-${{ github.event.pull_request.number }}
+            mkdir -p pr-previews/pr-${{ github.event.pull_request.number }}
+            cp -r $GITHUB_WORKSPACE/docs-app/dist/* pr-previews/pr-${{ github.event.pull_request.number }}/
+            git add .
+            if git diff --staged --quiet; then
+              echo "No changes to deploy"
+              exit 0
+            fi
+            git commit -m "Deploy docs preview for PR #${{ github.event.pull_request.number }} (${{ github.event.pull_request.head.sha }})"
+            if git push; then
+              exit 0
+            fi
+            echo "Push rejected (attempt $i), retrying against latest gh-pages..."
+            git reset --hard HEAD~1
+            git fetch origin gh-pages
+            git reset --hard origin/gh-pages
+            sleep $((RANDOM % 5 + 1))
+          done
+          echo "Failed to push to gh-pages after retries"
+          exit 1
 
       - name: Post or update preview comment
         uses: actions/github-script@v7
@@ -123,9 +139,24 @@ jobs:
           if [ -d "pr-previews/pr-${{ github.event.pull_request.number }}" ]; then
             git config --global user.name 'Patrick Pircher'
             git config --global user.email 'patricklx@users.noreply.github.com'
-            git rm -rf pr-previews/pr-${{ github.event.pull_request.number }}
-            git commit -m "Remove docs preview for PR #${{ github.event.pull_request.number }}"
-            git push
+            for i in 1 2 3 4 5; do
+              if [ ! -d "pr-previews/pr-${{ github.event.pull_request.number }}" ]; then
+                echo "Preview already removed"
+                exit 0
+              fi
+              git rm -rf pr-previews/pr-${{ github.event.pull_request.number }}
+              git commit -m "Remove docs preview for PR #${{ github.event.pull_request.number }}"
+              if git push; then
+                exit 0
+              fi
+              echo "Push rejected (attempt $i), retrying against latest gh-pages..."
+              git reset --hard HEAD~1
+              git fetch origin gh-pages
+              git reset --hard origin/gh-pages
+              sleep $((RANDOM % 5 + 1))
+            done
+            echo "Failed to push to gh-pages after retries"
+            exit 1
           fi
 
       - name: Update preview comment


### PR DESCRIPTION
## Summary
- The "PR Docs Preview" workflow's deploy and cleanup jobs each did a single `git push` to `gh-pages` with no retry, so when two PR preview jobs ran close together, the second push failed with `! [rejected] gh-pages -> gh-pages (fetch first)`.
- Both jobs now retry up to 5 times: on a rejected push, reset to the latest `origin/gh-pages` tip and redo the change (re-copy the built docs / re-remove the preview dir) before pushing again.

## Test plan
- [ ] Open two PRs (or push+relabel quickly) with the `preview` label around the same time and confirm both preview deploys succeed without a failed "Deploy Preview" check.
- [ ] Close a previewed PR and confirm the cleanup job still removes its preview directory.