### PR TITLE
fix: update DataTable for xs sizing and header association (#707)

### DIFF
--- a/.parity-check-data.json
+++ b/.parity-check-data.json
@@ -384,7 +384,7 @@
     },
     "DataTable": {
       "lastCheckedCommit": "5102bd860864c2580048183ffaf50d1ffd4400b5",
-      "lastSyncedCommit": "N/A",
+      "lastSyncedCommit": "a57cf8a896fe3fe09c5ab27648cd58947f37360a",
       "hasChanges": false,
       "changeCount": 0,
       "lastUpdate": null

--- a/carbon-components-ember/src/components/data-table.gts
+++ b/carbon-components-ember/src/components/data-table.gts
@@ -118,7 +118,7 @@ export interface DataTableComponentSignature<T> {
           typeof DataTableBody<T>,
           'table' | 'isExpandable' | 'isCheckable' | 'items'
         >;
-        Column: typeof TableColumn;
+        Column: WithBoundArgs<typeof TableColumn, 'table'>;
         Menu: typeof TableMenuComponent;
         Header: WithBoundArgs<typeof ListHeaderComponent, 'table'>;
       },
@@ -133,6 +133,10 @@ export default class DataTableComponent<T> extends Component<
   declare isExpandable: boolean;
   declare isCheckable: boolean;
   declare headers: Header[];
+  declare headerIds: (string | undefined)[];
+  // incremented by each Column instance to associate it with its header id;
+  // reset to 0 by each Row so column position stays 1:1 with the headers array
+  columnIndexCounter = 0;
 
   @defaultArgs
   args: Args<T> = {
@@ -290,7 +294,7 @@ export default class DataTableComponent<T> extends Component<
           )
           Menu=Menu
           Table=(component Table isLoading=@isLoading)
-          Column=ListColumn
+          Column=(component ListColumn table=this)
           EachBodyRows=(component
             ListBody
             isExpandable=this.isExpandable

--- a/carbon-components-ember/src/components/data-table/-column.gts
+++ b/carbon-components-ember/src/components/data-table/-column.gts
@@ -1,15 +1,42 @@
 import Component from '@glimmer/component';
+import type DataTableComponent from '../data-table.gts';
+
+export type Args = {
+  table?: DataTableComponent<any>;
+  // overrides the auto-associated header id used for the `headers` attribute
+  header?: string;
+};
 
 export interface TableColumnSignature {
-  Element: HTMLDivElement;
+  Args: Args;
+  Element: HTMLTableCellElement;
   Blocks: {
     default: [];
   };
 }
 
 export default class TableColumn extends Component<TableColumnSignature> {
+  // captures this column's position among its row's Column instances, so it
+  // can be matched up with the corresponding header's id
+  columnIndex?: number;
+
+  constructor(
+    ...args: ConstructorParameters<typeof Component<TableColumnSignature>>
+  ) {
+    super(...args);
+    if (this.args.table) {
+      this.columnIndex = this.args.table.columnIndexCounter++;
+    }
+  }
+
+  get headerId() {
+    if (this.args.header) return this.args.header;
+    if (this.columnIndex === undefined) return undefined;
+    return this.args.table?.headerIds?.[this.columnIndex];
+  }
+
   <template>
-    <td ...attributes>
+    <td headers={{this.headerId}} ...attributes>
       {{yield}}
     </td>
   </template>

--- a/carbon-components-ember/src/components/data-table/-header.gts
+++ b/carbon-components-ember/src/components/data-table/-header.gts
@@ -1,6 +1,9 @@
 import { default as Button } from '../button.gts';
 import { default as Checkbox } from '../checkbox.gts';
 import Component from '@glimmer/component';
+import { cached } from '@glimmer/tracking';
+import { guidFor } from '@ember/object/internals';
+import { get } from '@ember/helper';
 import type DataTableComponent from '../data-table.gts';
 
 export type Header = {
@@ -19,6 +22,18 @@ export default class ListHeaderComponent extends Component<Args> {
   didSetup = false;
   table?: DataTableComponent<any>;
 
+  @cached
+  get guid() {
+    return guidFor(this);
+  }
+
+  @cached
+  get headerIds(): (string | undefined)[] {
+    return this.args.headers.map((h, index) =>
+      h ? `data-table-${this.guid}__header-${index}` : undefined,
+    );
+  }
+
   constructor(...args: ConstructorParameters<typeof Component<Args>>) {
     super(...args);
     if (this.args.table) {
@@ -27,6 +42,10 @@ export default class ListHeaderComponent extends Component<Args> {
       Object.defineProperty(this.args.table, 'headers', {
         configurable: true,
         get: () => this.args.headers,
+      });
+      Object.defineProperty(this.args.table, 'headerIds', {
+        configurable: true,
+        get: () => this.headerIds,
       });
       Object.defineProperty(this.args.table, 'isExpandable', {
         configurable: true,
@@ -57,8 +76,8 @@ export default class ListHeaderComponent extends Component<Args> {
             />
           </th>
         {{/if}}
-        {{#each @headers as |h|}}
-          <th>
+        {{#each @headers as |h index|}}
+          <th id={{get this.headerIds index}}>
             {{#if h.sortable}}
               <Button @type='primary' class='cds--table-sort' title={{h.label}}>
                 <span class='cds--table-header-label'>

--- a/carbon-components-ember/src/components/data-table/-row.gts
+++ b/carbon-components-ember/src/components/data-table/-row.gts
@@ -29,6 +29,15 @@ export default class DataTableRow<T> extends Component<
 > {
   @tracked isExpanded: boolean = false;
 
+  constructor(
+    ...args: ConstructorParameters<typeof Component<DataTableRowSignature<T>>>
+  ) {
+    super(...args);
+    if (this.args.table) {
+      this.args.table.columnIndexCounter = 0;
+    }
+  }
+
   <template>
     <tr
       class='{{if

--- a/carbon-components-ember/src/components/data-table/-search-input.gts
+++ b/carbon-components-ember/src/components/data-table/-search-input.gts
@@ -12,6 +12,7 @@ export type Args = {
   isLoading: boolean;
   expandable?: boolean;
   value: string;
+  size?: 'xs' | 'sm' | 'md' | 'lg';
 };
 
 export default class TableSearchComponent extends Component<Args> {
@@ -50,6 +51,7 @@ export default class TableSearchComponent extends Component<Args> {
       @isLoading={{@isLoading}}
       @value={{@value}}
       @expandable={{@expandable}}
+      @size={{@size}}
       @onChange={{this.doSearch}}
       class='{{if this.isSearching this.styles.is-searching}}'
     />

--- a/carbon-components-ember/src/components/data-table/-toolbar.gts
+++ b/carbon-components-ember/src/components/data-table/-toolbar.gts
@@ -3,11 +3,14 @@ import TableToolbarContentComponent from '../data-table/-toolbar/-content.gts';
 import TableActionsComponent from '../data-table/-toolbar/-actions.gts';
 import type { WithBoundArgs } from '@glint/template';
 import DataTableComponent from '../data-table.gts';
-import { hash } from '@ember/helper';
+import { concat, hash } from '@ember/helper';
+import { default as defaultTo } from '../../helpers/default-to.ts';
 
 export interface Signature {
   Args: {
     table: DataTableComponent<any>;
+    size?: 'xs' | 'sm' | 'lg';
+    ariaLabel?: string;
   };
   Element: null;
   Blocks: {
@@ -22,7 +25,12 @@ export interface Signature {
 
 export default class TableToolbarComponent extends Component<Signature> {
   <template>
-    <section class='cds--table-toolbar'>
+    <section
+      class='cds--table-toolbar
+        {{if @size (concat "cds--table-toolbar--" @size)}}'
+      role='group'
+      aria-label={{defaultTo @ariaLabel 'data table toolbar'}}
+    >
       {{yield
         (hash
           Content=TableToolbarContentComponent

--- a/carbon-components-ember/src/components/pagination.gts
+++ b/carbon-components-ember/src/components/pagination.gts
@@ -3,7 +3,7 @@ import { default as defaultTo } from '../helpers/default-to.ts';
 import { default as eq } from 'ember-truth-helpers/helpers/eq';
 import { default as didInsert } from '@ember/render-modifiers/modifiers/did-insert';
 import { default as didUpdate } from '@ember/render-modifiers/modifiers/did-update';
-import { array, fn } from '@ember/helper';
+import { array, concat, fn } from '@ember/helper';
 import { on } from '@ember/modifier';
 import { default as or } from 'ember-truth-helpers/helpers/or';
 import Component from '@glimmer/component';
@@ -35,6 +35,7 @@ export type Args = {
   onPageChanged: (currentSlice: Slice) => void;
   state?: State;
   itemsPerPageOptions?: (number | string)[];
+  size?: 'xs' | 'sm' | 'md' | 'lg';
 };
 
 export default class CarbonPagination extends Component<Args> {
@@ -47,6 +48,7 @@ export default class CarbonPagination extends Component<Args> {
     onPageChanged: () => null,
     state: undefined,
     itemsPerPageOptions: undefined,
+    size: 'md',
   });
 
   get defaultArgs() {
@@ -137,7 +139,7 @@ export default class CarbonPagination extends Component<Args> {
 
   <template>
     <div
-      class='cds--pagination cds--pagination--md
+      class='cds--pagination {{concat "cds--pagination--" this.defaultArgs.size}}
         {{this.styles.namespace}}
         {{if @isLoading "cds--skeleton"}}'
       data-pagination

--- a/docs-app/app/templates/2-components/data-table.md
+++ b/docs-app/app/templates/2-components/data-table.md
@@ -159,6 +159,56 @@ const state = cell();
 
 </details>
 
+<details><summary>xs toolbar and pagination</summary>
+The Toolbar, its Search and the Pagination each accept their own `@size`
+argument (`xs`, `sm`, `md` or `lg`, depending on the sub-component). Every
+`<td>` is also automatically linked to its column's `<th>` via the `headers`
+attribute for screen-reader users.
+
+```gjs live preview
+import { array, hash } from '@ember/helper';
+import { DataTable } from 'carbon-components-ember/components';
+import { ThemeSupport } from 'docs-support';
+
+<template>
+    <ThemeSupport />
+    <DataTable
+        @title='Table title'
+        @items={{array (hash name='a' b='c') (hash name='John' b='asd')}}
+        as |table|
+    >
+        <table.Toolbar @size='xs' as |toolbar|>
+            <toolbar.Content>
+                <table.SearchInput @size='xs' @expandable={{true}} />
+            </toolbar.Content>
+        </table.Toolbar>
+        <table.Table @size='xs'>
+            <table.Header
+                @headers={{array (hash label='Name') (hash label='details') null}}
+            />
+            <table.EachBodyRows as |row|>
+                <row.Row>
+                    <table.Column>
+                        {{row.item.name}}
+                    </table.Column>
+                    <table.Column>
+                        {{row.item.b}}
+                    </table.Column>
+                    <table.Menu as |Item|>
+                        <Item>
+                            Edit
+                        </Item>
+                    </table.Menu>
+                </row.Row>
+            </table.EachBodyRows>
+        </table.Table>
+        <table.Pagination @size='xs' />
+    </DataTable>
+</template>
+```
+
+</details>
+
 
 ## API Reference
 

--- a/docs-app/app/templates/2-components/pagination.md
+++ b/docs-app/app/templates/2-components/pagination.md
@@ -63,6 +63,24 @@ const not = (x) => !x;
 </template>
 ```
 
+<details><summary>sizes</summary>
+Pagination supports `xs`, `sm`, `md` and `lg` sizes via the `@size` argument.
+
+```gjs live preview
+import { Pagination } from 'carbon-components-ember/components';
+import { ThemeSupport } from 'docs-support';
+
+<template>
+    <ThemeSupport />
+    <Pagination @size='xs' @length={{100}} @onPageChanged={{() => {}}} />
+    <Pagination @size='sm' @length={{100}} @onPageChanged={{() => {}}} />
+    <Pagination @size='md' @length={{100}} @onPageChanged={{() => {}}} />
+    <Pagination @size='lg' @length={{100}} @onPageChanged={{() => {}}} />
+</template>
+```
+
+</details>
+
 ## API Reference
 
 <details>

--- a/test-app/tests/components/data-table-test.gts
+++ b/test-app/tests/components/data-table-test.gts
@@ -1,0 +1,167 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import { array, hash } from '@ember/helper';
+import DataTable from 'carbon-components-ember/components/data-table';
+import Pagination from 'carbon-components-ember/components/pagination';
+
+const noop = () => undefined;
+
+module('Integration | Component | DataTable', (hooks) => {
+  setupRenderingTest(hooks);
+
+  const items = [
+    { name: 'a', b: 'c' },
+    { name: 'John', b: 'asd' },
+  ];
+
+  test('should render title, description and rows', async function (assert) {
+    await render(
+      <template>
+        <DataTable
+          @title='Table title'
+          @description='Table description'
+          @items={{items}}
+          as |table|
+        >
+          <table.Table>
+            <table.Header
+              @headers={{array (hash label='Name') (hash label='details')}}
+            />
+            <table.EachBodyRows as |row|>
+              <row.Row>
+                <table.Column>{{row.item.name}}</table.Column>
+                <table.Column>{{row.item.b}}</table.Column>
+              </row.Row>
+            </table.EachBodyRows>
+          </table.Table>
+        </DataTable>
+      </template>,
+    );
+
+    assert.dom('.cds--data-table-header__title').hasText('Table title');
+    assert
+      .dom('.cds--data-table-header__description')
+      .hasText('Table description');
+    assert.dom('table.cds--data-table').exists();
+    assert.dom('thead th').exists({ count: 2 });
+    assert.dom('tbody tr').exists({ count: 2 });
+  });
+
+  test('should associate each td with its column header via the headers attribute', async function (assert) {
+    await render(
+      <template>
+        <DataTable @title='Table title' @items={{items}} as |table|>
+          <table.Table>
+            <table.Header
+              @headers={{array (hash label='Name') (hash label='details')}}
+            />
+            <table.EachBodyRows as |row|>
+              <row.Row>
+                <table.Column>{{row.item.name}}</table.Column>
+                <table.Column>{{row.item.b}}</table.Column>
+              </row.Row>
+            </table.EachBodyRows>
+          </table.Table>
+        </DataTable>
+      </template>,
+    );
+
+    const headerIds = Array.from(document.querySelectorAll('thead th')).map(
+      (th) => th.id,
+    );
+    assert.strictEqual(headerIds.length, 2);
+    assert.ok(headerIds.every((id) => !!id));
+
+    const rows = document.querySelectorAll('tbody tr');
+    assert.strictEqual(rows.length, 2);
+    for (const row of rows) {
+      const cells = row.querySelectorAll('td');
+      assert.strictEqual(
+        cells[0]?.getAttribute('headers'),
+        headerIds[0],
+        'first column links to first header',
+      );
+      assert.strictEqual(
+        cells[1]?.getAttribute('headers'),
+        headerIds[1],
+        'second column links to second header',
+      );
+    }
+  });
+
+  test('should support an xs sized toolbar and forward size to the search input', async function (assert) {
+    await render(
+      <template>
+        <DataTable @title='Table title' @items={{items}} as |table|>
+          <table.Toolbar @size='xs' as |toolbar|>
+            <toolbar.Content>
+              <table.SearchInput @size='xs' />
+            </toolbar.Content>
+          </table.Toolbar>
+        </DataTable>
+      </template>,
+    );
+
+    assert.dom('.cds--table-toolbar').hasClass('cds--table-toolbar--xs');
+    assert.dom('.cds--table-toolbar').hasAttribute('role', 'group');
+    assert
+      .dom('.cds--table-toolbar')
+      .hasAttribute('aria-label', 'data table toolbar');
+    assert.dom('.cds--search').hasClass('cds--search--xs');
+  });
+
+  test('should support checkable rows and selection', async function (assert) {
+    await render(
+      <template>
+        <DataTable @title='Table title' @items={{items}} as |table|>
+          <table.Table>
+            <table.Header
+              @isCheckable={{true}}
+              @headers={{array (hash label='Name') (hash label='details')}}
+            />
+            <table.EachBodyRows as |row|>
+              <row.Row @isCheckable={{true}}>
+                <table.Column>{{row.item.name}}</table.Column>
+                <table.Column>{{row.item.b}}</table.Column>
+              </row.Row>
+            </table.EachBodyRows>
+          </table.Table>
+        </DataTable>
+      </template>,
+    );
+
+    assert.dom('thead .cds--table-column-checkbox input').exists();
+    assert.dom('tbody .cds--table-column-checkbox input').exists({
+      count: 2,
+    });
+  });
+});
+
+module('Integration | Component | Pagination', (hooks) => {
+  setupRenderingTest(hooks);
+
+  test('should default to the md size', async function (assert) {
+    await render(
+      <template>
+        <Pagination @length={{10}} @onPageChanged={{noop}} />
+      </template>,
+    );
+
+    assert.dom('.cds--pagination').hasClass('cds--pagination--md');
+  });
+
+  test('should support an xs size', async function (assert) {
+    await render(
+      <template>
+        <Pagination
+          @length={{10}}
+          @size='xs'
+          @onPageChanged={{noop}}
+        />
+      </template>,
+    );
+
+    assert.dom('.cds--pagination').hasClass('cds--pagination--xs');
+  });
+});


### PR DESCRIPTION
Closes #707

## Summary
Parity-check update for DataTable against Carbon React (7 upstream commits, incl. #22509, #22322, #22347, #22268, #22169).

Investigated each recent React change:
- **overflow-menu contextual layout tokens** (#22509) — CSS-only via `@carbon/styles`, already at 1.112.0. No component code change needed.
- **`aria-labelledby` search landmark labeling** (#22347) — already implemented in Ember's `search.gts`, matches React exactly. No change needed.
- **DataTable pagination story with xs support** (#22322) — Ember's `Pagination` had **no `@size` argument at all**. Added `@size?: 'xs' | 'sm' | 'md' | 'lg'` (defaults to `md`, matching prior behavior).
- **TableToolbar xs size** (#22268) — Ember's `Toolbar`/`SearchInput` (within DataTable) had no `@size` support. Added `@size` to the toolbar section (`cds--table-toolbar--{size}`, plus `role="group"` and a default `aria-label="data table toolbar"`), and forwarded `@size` through the DataTable search wrapper to the already-`size`-capable `Search` primitive.
- **Associate TableCells with column headers** (#22169) — a11y fix so screen readers can map a `<td>` back to its `<th>`. Ember's table had no `id`/`headers` wiring at all. Added automatic `id` generation on each `<th>` and a matching `headers` attribute on each `<td>` rendered via `table.Column`, using row-scoped positional tracking (mirrors the existing pattern already used to share `headers`/`isExpandable`/`isCheckable` onto the table instance). An explicit `@header` override is also available for consumers who need to opt out of the automatic association.

Since Ember's DataTable doesn't have React's context mechanism, `@size` is set independently on `Toolbar`, `SearchInput`, `Table` and `Pagination` rather than propagating automatically — consistent with how this component already handles other per-subcomponent args (e.g. `@expandable`).

## Changes
- `pagination.gts`: add `@size` arg + class
- `data-table/-toolbar.gts`: add `@size`, `role="group"`, default `aria-label`
- `data-table/-search-input.gts`: forward `@size` to the underlying `Search`
- `data-table/-header.gts` + `data-table/-column.gts` + `data-table/-row.gts`: automatic `id`/`headers` association between `<th>` and `<td>`
- Docs: new live-preview examples for xs toolbar/pagination sizing in `data-table.md`, and a sizes example in `pagination.md`
- Tests: new `data-table-test.gts` covering rendering, header/column association, toolbar sizing, and checkable rows; plus Pagination size coverage

## Test plan
- [x] `pnpm build` succeeds
- [x] Full test-app suite passes (448/448), including 6 new tests