### PR TITLE
fix(docs): resolve the real source path for "Edit this page"

### DIFF
--- a/docs-app/app/components/edit-this-page.gts
+++ b/docs-app/app/components/edit-this-page.gts
@@ -1,0 +1,53 @@
+import Component from '@glimmer/component';
+import { service } from '@ember/service';
+
+import { docsManager } from 'kolay';
+
+import type RouterService from '@ember/routing/router-service';
+import type { ComponentLike } from '@glint/template';
+
+/**
+ * GitHub's edit URL for the directory kolay globs the docs' markdown out of.
+ * A page's manifest `appRelativePath` is its location under that directory,
+ * extension included (e.g. `/2-components/skeleton/icon.md`), so the two
+ * concatenate into the source file's URL.
+ */
+const EDIT_ROOT = 'https://github.com/IBM/carbon-components-ember/edit/main/docs-app/app/templates';
+
+export class EditThisPage extends Component<{
+  Args: {
+    /**
+     * The `EditLink` component yielded by `PageLayout`'s `editLink` block.
+     */
+    link: ComponentLike<{ Args: { href: string }; Blocks: { default: [] } }>;
+  };
+}> {
+  @service declare router: RouterService;
+
+  /**
+   * kolay's docs service keeps its selected-page state private, so the current
+   * page is resolved the way that state does: `router.currentURL` is
+   * app-relative (ember's location layer already stripped the rootURL), so
+   * dropping any query params / hash leaves a path the manifest can be searched
+   * by -- with or without the `.md` extension, since both are visitable.
+   */
+  get href() {
+    const [path] = this.router.currentURL?.split(/[?#]/) ?? [];
+
+    if (!path) return;
+
+    const page = docsManager(this).findByPath(path);
+
+    if (!page) return;
+
+    return `${EDIT_ROOT}${page.appRelativePath}`;
+  }
+
+  <template>
+    {{#if this.href}}
+      <@link @href={{this.href}}>
+        Edit this page
+      </@link>
+    {{/if}}
+  </template>
+}

--- a/docs-app/app/templates/page.gts
+++ b/docs-app/app/templates/page.gts
@@ -1,6 +1,7 @@
+import { EditThisPage } from 'docs-app/components/edit-this-page';
 import { GitHubLink, TestsLink } from 'docs-app/components/header';
 import { Logo, Logomark } from 'docs-app/components/icons';
-import { ExternalLink, service } from 'ember-primitives';
+import { ExternalLink } from 'ember-primitives';
 import Route from 'ember-route-template';
 
 import { OopsError, PageLayout } from '@universal-ember/docs-support';
@@ -23,13 +24,7 @@ export default Route(
         </OopsError>
       </:error>
       <:editLink as |Link|>
-        {{#let (service "kolay/docs") as |docs|}}
-          <Link
-            @href="https://github.com/IBM/carbon-components-ember/edit/main/docs-app/app/templates{{docs.selected.path}}.md"
-          >
-            Edit this page
-          </Link>
-        {{/let}}
+        <EditThisPage @link={{Link}} />
       </:editLink>
     </PageLayout>
   </template>


### PR DESCRIPTION
## Summary
- `(service "kolay/docs")` resolved to `undefined` — kolay doesn't register anything in Ember's container; its docs state lives in an ember-primitives store reached via `docsManager()`.
- Resolves the current page the way kolay's own private selected-page state does: strips query params/hash from the app-relative `router.currentURL` and looks it up with `findByPath` (matches with or without `.md`).
- Fixes every "Edit this page" link, which previously pointed at a 404 (`docs-app/app/templates.md`).

## Test plan
- [x] Verified against a production build served under a rootURL: link resolves correctly for a top-level page, a page inside a family folder (`2-components/skeleton/icon.md`), a family index page, and the extension-less form of a URL.
- [x] `pnpm glint` in docs-app shows no new errors introduced by this change (pre-existing unrelated errors in `theme-support.gts`/`application.ts` are untouched).

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>