### PR TITLE
fix(docs-app): remove dead docs-app.css link from index.html

### DIFF
--- a/docs-app/index.html
+++ b/docs-app/index.html
@@ -8,7 +8,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
 
     <link integrity="" rel="stylesheet" href="/@embroider/virtual/vendor.css" />
-    <link integrity="" rel="stylesheet" href="/assets/docs-app.css" />
 
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />


### PR DESCRIPTION
## Summary
- `docs-app/index.html` linked a root-absolute `/assets/docs-app.css` stylesheet that Vite never emits (it only produces a hashed `main-<hash>.css` bundle, auto-injected by Vite itself) — a leftover from the classic ember-cli build convention that never got translated during the embroider/vite migration in #293.
- This link 404'd in every deployed build. Removed it.

## Test plan
- [x] Confirmed no other references to `docs-app.css` remain in the repo