### PR TITLE
feat: bring Tag component to parity with React

### DIFF
--- a/.parity-check-data.json
+++ b/.parity-check-data.json
@@ -531,7 +531,7 @@
     },
     "Tag": {
       "lastCheckedCommit": "5102bd860864c2580048183ffaf50d1ffd4400b5",
-      "lastSyncedCommit": "N/A",
+      "lastSyncedCommit": "a57cf8a896fe3fe09c5ab27648cd58947f37360a",
       "hasChanges": false,
       "changeCount": 0,
       "lastUpdate": null

--- a/carbon-components-ember/src/components/tag.gts
+++ b/carbon-components-ember/src/components/tag.gts
@@ -1,6 +1,36 @@
 import Component from '@glimmer/component';
+import { guidFor } from '@ember/object/internals';
+import type { ComponentLike } from '@glint/template';
 
 export type Args = {
+  /**
+   * Specify the id for the tag.
+   */
+  id?: string;
+  /**
+   * Specify if the `Tag` is disabled.
+   */
+  disabled?: boolean;
+  /**
+   * A component used to render an icon.
+   */
+  renderIcon?: ComponentLike;
+  /**
+   * Specify the size of the Tag. Currently supports either `sm`, `md`
+   * (default) or `lg` sizes.
+   */
+  size?: 'sm' | 'md' | 'lg';
+  /**
+   * **Experimental:** Provide a `decorator` component (e.g. AILabel) to be
+   * rendered inside the Tag.
+   */
+  decorator?: ComponentLike;
+  /**
+   * @deprecated please use `decorator` instead.
+   * **Experimental:** Provide a Slug/AILabel component to be rendered
+   * inside the Tag.
+   */
+  slug?: ComponentLike;
   type:
     | 'red'
     | 'magenta'
@@ -11,7 +41,9 @@ export type Args = {
     | 'green'
     | 'gray'
     | 'cool-gray'
-    | 'warm-gray';
+    | 'warm-gray'
+    | 'high-contrast'
+    | 'outline';
 };
 
 export interface TagInterface {
@@ -23,9 +55,15 @@ export interface TagInterface {
 }
 
 export default class TagComponent extends Component<TagInterface> {
+  guid = guidFor(this);
+
+  get id() {
+    return this.args.id ?? `tag-${this.guid}`;
+  }
+
   get type() {
     const types =
-      'red magenta purple blue cyan teal green gray cool-gray warm-gray'.split(
+      'red magenta purple blue cyan teal green gray cool-gray warm-gray high-contrast outline'.split(
         ' ',
       );
     if (!types.includes(this.args.type)) {
@@ -38,9 +76,37 @@ export default class TagComponent extends Component<TagInterface> {
     return this.args.type;
   }
 
+  get classes() {
+    const classes = ['cds--tag', `cds--tag--${this.type}`];
+    if (this.args.disabled) classes.push('cds--tag--disabled');
+    if (this.args.size) {
+      classes.push(`cds--tag--${this.args.size}`);
+      classes.push(`cds--layout--size-${this.args.size}`);
+    }
+    return classes.join(' ');
+  }
+
+  get showIcon() {
+    return !!this.args.renderIcon && this.args.size !== 'sm';
+  }
+
   <template>
-    <div class='cds--tag cds--tag--{{this.type}}' ...attributes>
-      {{yield}}
+    <div class={{this.classes}} id={{this.id}} ...attributes>
+      {{#if this.showIcon}}
+        <div class='cds--tag__custom-icon'>
+          <@renderIcon />
+        </div>
+      {{/if}}
+      <span class='cds--tag__label'>
+        {{yield}}
+      </span>
+      {{#if @slug}}
+        <@slug />
+      {{else if @decorator}}
+        <div class='cds--tag__decorator'>
+          <@decorator />
+        </div>
+      {{/if}}
     </div>
   </template>
 }

--- a/carbon-components-ember/src/components/tag.gts
+++ b/carbon-components-ember/src/components/tag.gts
@@ -1,6 +1,7 @@
 import Component from '@glimmer/component';
 import { guidFor } from '@ember/object/internals';
 import type { ComponentLike } from '@glint/template';
+import type Icon from './icon.gts';
 
 export type Args = {
   /**
@@ -14,7 +15,7 @@ export type Args = {
   /**
    * A component used to render an icon.
    */
-  renderIcon?: ComponentLike;
+  renderIcon?: typeof Icon;
   /**
    * Specify the size of the Tag. Currently supports either `sm`, `md`
    * (default) or `lg` sizes.
@@ -94,7 +95,7 @@ export default class TagComponent extends Component<TagInterface> {
     <div class={{this.classes}} id={{this.id}} ...attributes>
       {{#if this.showIcon}}
         <div class='cds--tag__custom-icon'>
-          <@renderIcon />
+          <@renderIcon @size='16' @svgClass='cds--tag__custom-icon-svg' />
         </div>
       {{/if}}
       <span class='cds--tag__label'>

--- a/docs-app/app/templates/2-components/tags.md
+++ b/docs-app/app/templates/2-components/tags.md
@@ -100,7 +100,11 @@ import { ThemeSupport } from 'docs-support';
 <template>
   <ThemeSupport />
   <br>
-  <Tag @type='red' @renderIcon={{Add}} @decorator={{Add}}>With decorator</Tag>
+  <Tag
+    @type='red'
+    @renderIcon={{Add}}
+    @decorator={{component Add size='16'}}
+  >With decorator</Tag>
 </template>
 ```
 

--- a/docs-app/app/templates/2-components/tags.md
+++ b/docs-app/app/templates/2-components/tags.md
@@ -19,6 +19,8 @@ const context = trackedObject({
     'gray',
     'cool-gray',
     'warm-gray',
+    'high-contrast',
+    'outline',
   ]
 });
 
@@ -33,6 +35,72 @@ const context = trackedObject({
           {{type}}
         </Tag>
       {{/each}}
+</template>
+```
+
+## Sizes
+
+`@size` supports `sm`, `md` (default) or `lg`.
+
+```gjs live preview
+import { Tag } from 'carbon-components-ember/components';
+import { ThemeSupport } from 'docs-support';
+
+<template>
+  <ThemeSupport />
+  <br>
+  <Tag @type='blue' @size='sm'>Small</Tag>
+  <Tag @type='blue' @size='md'>Medium</Tag>
+  <Tag @type='blue' @size='lg'>Large</Tag>
+</template>
+```
+
+## Disabled
+
+```gjs live preview
+import { Tag } from 'carbon-components-ember/components';
+import { ThemeSupport } from 'docs-support';
+
+<template>
+  <ThemeSupport />
+  <br>
+  <Tag @type='blue' @disabled={{true}}>Disabled</Tag>
+</template>
+```
+
+## With icon
+
+Provide a `@renderIcon` component to render an icon inside the tag. The icon
+is hidden for the `sm` size.
+
+```gjs live preview
+import { Tag } from 'carbon-components-ember/components';
+import { Asleep } from 'carbon-components-ember/icons';
+import { ThemeSupport } from 'docs-support';
+
+<template>
+  <ThemeSupport />
+  <br>
+  <Tag @type='blue' @renderIcon={{Asleep}}>With icon</Tag>
+</template>
+```
+
+## With decorator
+
+**Experimental:** Provide a `@decorator` (or the deprecated `@slug`) component
+to render inside the Tag, such as an AILabel once it's available (see
+[AILabel #406](https://github.com/IBM/carbon-components-ember/issues/406)).
+In the meantime, any component can be used as a placeholder.
+
+```gjs live preview
+import { Tag } from 'carbon-components-ember/components';
+import { Add } from 'carbon-components-ember/icons';
+import { ThemeSupport } from 'docs-support';
+
+<template>
+  <ThemeSupport />
+  <br>
+  <Tag @type='red' @renderIcon={{Add}} @decorator={{Add}}>With decorator</Tag>
 </template>
 ```
 

--- a/test-app/tests/components/tag-test.gts
+++ b/test-app/tests/components/tag-test.gts
@@ -1,0 +1,96 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render, waitUntil, find } from '@ember/test-helpers';
+import Tag from 'carbon-components-ember/components/tag';
+import { Add } from 'carbon-components-ember/icons';
+
+module('Integration | Component | Tag', (hooks) => {
+  setupRenderingTest(hooks);
+
+  test('should render with the given type', async function (assert) {
+    await render(<template><Tag @type='red'>Tag content</Tag></template>);
+
+    assert.dom('.cds--tag').exists();
+    assert.dom('.cds--tag').hasClass('cds--tag--red');
+    assert.dom('.cds--tag__label').hasText('Tag content');
+  });
+
+  test('should render the high-contrast and outline types', async function (assert) {
+    await render(
+      <template><Tag @type='high-contrast'>Tag content</Tag></template>,
+    );
+    assert.dom('.cds--tag').hasClass('cds--tag--high-contrast');
+
+    await render(<template><Tag @type='outline'>Tag content</Tag></template>);
+    assert.dom('.cds--tag').hasClass('cds--tag--outline');
+  });
+
+  test('should generate a default id', async function (assert) {
+    await render(<template><Tag @type='red'>Tag content</Tag></template>);
+
+    assert.dom('.cds--tag').hasAttribute('id', /^tag-/);
+  });
+
+  test('should use the provided id', async function (assert) {
+    await render(
+      <template><Tag @type='red' @id='my-tag'>Tag content</Tag></template>,
+    );
+
+    assert.dom('.cds--tag').hasAttribute('id', 'my-tag');
+  });
+
+  test('should apply the disabled class', async function (assert) {
+    await render(
+      <template><Tag @type='red' @disabled={{true}}>Tag content</Tag></template>,
+    );
+
+    assert.dom('.cds--tag').hasClass('cds--tag--disabled');
+  });
+
+  test('should apply the size classes', async function (assert) {
+    await render(
+      <template><Tag @type='red' @size='lg'>Tag content</Tag></template>,
+    );
+
+    assert.dom('.cds--tag').hasClass('cds--tag--lg');
+    assert.dom('.cds--tag').hasClass('cds--layout--size-lg');
+  });
+
+  test('should render a renderIcon component', async function (assert) {
+    await render(
+      <template><Tag @type='red' @renderIcon={{Add}}>Tag content</Tag></template>,
+    );
+    await waitUntil(() => find('.cds--tag__custom-icon svg'));
+
+    assert.dom('.cds--tag__custom-icon svg').exists();
+  });
+
+  test('should not render the icon wrapper for the sm size', async function (assert) {
+    await render(
+      <template>
+        <Tag @type='red' @size='sm' @renderIcon={{Add}}>Tag content</Tag>
+      </template>,
+    );
+
+    assert.dom('.cds--tag__custom-icon').doesNotExist();
+  });
+
+  test('should render a decorator component', async function (assert) {
+    await render(
+      <template><Tag @type='red' @decorator={{Add}}>Tag content</Tag></template>,
+    );
+    await waitUntil(() => find('.cds--tag__decorator svg'));
+
+    assert.dom('.cds--tag__decorator svg').exists();
+  });
+
+  test('should render a deprecated slug component without the decorator wrapper', async function (assert) {
+    await render(
+      <template><Tag @type='red' @slug={{Add}}>Tag content</Tag></template>,
+    );
+    await waitUntil(() => find('.cds--tag svg'));
+
+    assert.dom('.cds--tag__decorator').doesNotExist();
+    assert.dom('.cds--tag > svg').exists();
+  });
+});

--- a/test-app/tests/components/tag-test.gts
+++ b/test-app/tests/components/tag-test.gts
@@ -1,8 +1,12 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render, waitUntil, find } from '@ember/test-helpers';
+import { render, rerender, waitUntil, find } from '@ember/test-helpers';
 import Tag from 'carbon-components-ember/components/tag';
 import { Add } from 'carbon-components-ember/icons';
+import { cell } from 'ember-resources';
+import * as carbonStyle from '@carbon/styles/css/styles.css?inline';
+import type { RenderingTestContext } from '@ember/test-helpers/setup-rendering-context';
+import { waitForAnimationFrame } from '../helpers';
 
 module('Integration | Component | Tag', (hooks) => {
   setupRenderingTest(hooks);
@@ -63,6 +67,37 @@ module('Integration | Component | Tag', (hooks) => {
     await waitUntil(() => find('.cds--tag__custom-icon svg'));
 
     assert.dom('.cds--tag__custom-icon svg').exists();
+    assert.dom('.cds--tag__custom-icon svg').hasAttribute('width', '16');
+    assert.dom('.cds--tag__custom-icon svg').hasAttribute('height', '16');
+  });
+
+  test('positions the custom icon inside its wrapper under real Carbon styles', async function (this: RenderingTestContext, assert) {
+    const styleValue = cell('');
+    await render(
+      <template>
+        <Tag @type='red' @renderIcon={{Add}}>Tag content</Tag>
+        <style>{{styleValue.current}}</style>
+      </template>,
+    );
+    await waitUntil(() => find('.cds--tag__custom-icon svg'));
+    styleValue.current = carbonStyle.default;
+    await rerender();
+    await waitForAnimationFrame();
+
+    const wrapper = find('.cds--tag__custom-icon') as HTMLElement;
+    const svg = wrapper.querySelector('svg') as SVGElement;
+    const wrapperRect = wrapper.getBoundingClientRect();
+    const svgRect = svg.getBoundingClientRect();
+
+    assert.strictEqual(
+      getComputedStyle(svg).marginRight,
+      '0px',
+      'the icon has no default margin pushing it out of its 16px box',
+    );
+    assert.true(
+      svgRect.width <= wrapperRect.width && svgRect.height <= wrapperRect.height,
+      'the icon fits inside its wrapper instead of overflowing it',
+    );
   });
 
   test('should not render the icon wrapper for the sm size', async function (assert) {


### PR DESCRIPTION
Closes #718

## Summary
- Added `size` (`sm`/`md`/`lg`), `disabled`, `id`, `renderIcon`, `decorator`/`slug` (deprecated alias) args to `Tag`, matching React's `TagBaseProps`.
- Added the missing `high-contrast` and `outline` values to `type`.
- `className`/attribute passthrough (React's `className` prop) is already covered by `Element: HTMLDivElement` + `...attributes` — Ember's splattributes merge a passed `class` with the component's own `cds--tag*` classes automatically, no extra arg needed.
- Added docs examples for sizes, disabled state, icon and decorator.
- Added tests covering the new args.

## Out of scope
- `filter` / `onClose` / `title` are deprecated in React in favor of a separate `DismissibleTag` component, which doesn't exist in this addon yet and isn't tracked by the parity checker as its own component — left out of this PR rather than building deprecated behavior.
- React's `as` prop (polymorphic element, defaults to `button` when `onClick`/the operational class is present) isn't part of the public `TagBaseProps` interface — it only matters once an interactive/clickable Tag variant exists, which none of the React stories (`ReadOnly`, `Skeleton`, `withAILabel`) demonstrate and this Tag doesn't support an `onClick` arg. Left out; worth adding alongside `element` (from `ember-element-helper`) if/when an interactive Tag is implemented.
- React's automatic ellipsis-overflow tooltip (`isEllipsisActive` + `DefinitionTooltip`) isn't demonstrated by any story either. It could be built with a functional `modifier()` (see `-private/tooltip.gts`) for DOM measurement, so it's not that this repo lacks the pattern — it's left out purely to keep this change scoped to what the stories cover.
