### PR TITLE
chore: mark HideAtBreakpoint as excluded from parity tracking

### DIFF
--- a/.parity-check-exclusions.json
+++ b/.parity-check-exclusions.json
@@ -18,5 +18,10 @@
     "reason": "Tab is not a standalone React component — its source (packages/react/src/components/Tab/index.tsx) simply re-exports the Tab sub-component from Tabs/Tabs.tsx. It only exists as a child of Tabs > TabList and has no standalone usage. This functionality is already covered by the existing Ember Tabs component (src/components/tabs.gts), which is tracked and implemented separately.",
     "excludedAt": "2026-08-04T09:45:17.206Z",
     "issue": "702"
+  },
+  "HideAtBreakpoint": {
+    "reason": "HideAtBreakpoint is not a React component — it's a documentation-only Storybook 'Helpers' page demonstrating pure SCSS mixins (hide-at-sm/md/lg/xlg/max from @carbon/styles/scss/utilities/hide-at-breakpoint) applied via plain CSS class names. There is no component API to give an Ember counterpart; consumers apply the same @carbon/styles mixins directly in their own SCSS, which already works today via this addon's existing @carbon/styles dependency.",
+    "excludedAt": "2026-08-13T21:13:39.188Z",
+    "issue": "690"
   }
 }


### PR DESCRIPTION
## Summary
- `HideAtBreakpoint` is not an actual React component — `packages/react/src/components/HideAtBreakpoint/` in `carbon-design-system/carbon` contains only `HideAtBreakpoint.stories.js`, `HideAtBreakpoint-story.scss`, and `HideAtBreakpoint.mdx`. There is no `.tsx` or `index.ts`, no props, no JS behavior.
- It's a Storybook "Helpers" doc page demonstrating five pure-CSS SCSS mixins (`hide-at-sm`, `hide-at-md`, `hide-at-lg`, `hide-at-xlg`, `hide-at-max`) from `@carbon/styles/scss/utilities/hide-at-breakpoint`, each wrapping `display: none` in a media query.
- Consumers already have access to these mixins directly via this addon's existing `@carbon/styles` dependency — there's no component API to port, so this is excluded from parity tracking (Path C).
- This re-records an identical exclusion originally made for issue #453, whose commit was orphaned on an unmerged `fix-issue-453` branch and never reached `main`, causing the weekly parity-check to regenerate a duplicate issue (#690).

Closes #690

## Test plan
- [x] `node parity-check.mjs --exclude HideAtBreakpoint --reason ... --issue 690` run, `.parity-check-exclusions.json` updated
- N/A — no code changes, doc-only exclusion