### PR TITLE
chore: mark Icon as synced

### DIFF
--- a/.parity-check-data.json
+++ b/.parity-check-data.json
@@ -419,7 +419,7 @@
     },
     "Icon": {
       "lastCheckedCommit": "5102bd860864c2580048183ffaf50d1ffd4400b5",
-      "lastSyncedCommit": "N/A",
+      "lastSyncedCommit": "188d23202ec1092322dee92cf0df9d9958224ae4",
       "hasChanges": false,
       "changeCount": 0,
       "lastUpdate": null


### PR DESCRIPTION
Closes #691 — verified Icon already matches the React implementation, no changes needed.

Carbon React's `Icon/` directory no longer contains an active wrapper component (phased out in v10). The only surviving export, `IconSkeleton`, is already covered by Ember's `SkeletonIcon` component. The per-icon API that replaced the old wrapper (`@carbon/icons-react`) is already covered by this repo's `Icon` base component (`src/components/icon.gts`) plus the generated per-icon components under `src/components/icons/*`.

See issue comment for full details.