### PR TITLE
chore: mark Popover as synced

### DIFF
--- a/.parity-check-data.json
+++ b/.parity-check-data.json
@@ -734,7 +734,7 @@
     },
     "Popover": {
       "lastCheckedCommit": "5102bd860864c2580048183ffaf50d1ffd4400b5",
-      "lastSyncedCommit": "a57cf8a896fe3fe09c5ab27648cd58947f37360a",
+      "lastSyncedCommit": "188d23202ec1092322dee92cf0df9d9958224ae4",
       "hasChanges": false,
       "changeCount": 0,
       "lastUpdate": null


### PR DESCRIPTION
Closes #728 — verified Popover already matches the React implementation, no changes needed.

Popover was already implemented in #668 with full API parity: `align` (incl. deprecated alignment mapping), `as`, `autoAlign`/`autoAlignBoundary` (documented as a lighter-weight approximation of React's floating-ui-powered autoAlign), `backgroundToken`, `border`, `caret`, `dropShadow`, `highContrast`, `isTabTip`, `onRequestClose`, and `open`. `alignmentAxisOffset` is explicitly documented as not implemented (experimental, floating-ui-specific).

Compared against the current React source (`packages/react/src/components/Popover/index.tsx`) and all three stories (Default, TabTip, ExperimentalAutoAlign) — all covered by the existing docs, tests, and implementation. Issue #728 was auto-generated after #668 already landed, so this just marks the component synced in `.parity-check-data.json`.