### PR TITLE
fix: align Loading component with Carbon React API

### DIFF
--- a/.parity-check-data.json
+++ b/.parity-check-data.json
@@ -426,7 +426,7 @@
     },
     "Loading": {
       "lastCheckedCommit": "5102bd860864c2580048183ffaf50d1ffd4400b5",
-      "lastSyncedCommit": "N/A",
+      "lastSyncedCommit": "188d23202ec1092322dee92cf0df9d9958224ae4",
       "hasChanges": false,
       "changeCount": 0,
       "lastUpdate": null

--- a/carbon-components-ember/src/components/loading.gts
+++ b/carbon-components-ember/src/components/loading.gts
@@ -4,8 +4,8 @@ import { defaultArgs } from '../utils/decorators.ts';
 export type Args = {
   active?: boolean;
   small?: boolean;
-  overlay?: boolean;
-  title?: boolean;
+  withOverlay?: boolean;
+  description?: string;
   inline?: boolean;
   classNames?: string;
 };
@@ -19,8 +19,8 @@ export default class LoadingComponent extends Component<LoadingComponentSignatur
   args: Args = defaultArgs(this, {
     active: true,
     small: false,
-    overlay: false,
-    title: undefined,
+    withOverlay: true,
+    description: 'loading',
     inline: false,
     classNames: '',
   });
@@ -30,35 +30,10 @@ export default class LoadingComponent extends Component<LoadingComponentSignatur
   }
 
   <template>
-    {{#if this.defaultArgs.active}}
-      {{#if this.defaultArgs.overlay}}
-        <div class='cds--loading-overlay' style='height: 100%'>
-          <div
-            data-loading
-            class='cds--loading
-              {{if this.defaultArgs.small "cds--loading--small"}}
-              {{@classNames}}'
-            ...attributes
-          >
-            <svg class='cds--loading__svg' viewBox='-75 -75 150 150'>
-              <title>
-                {{@title}}
-              </title>
-              {{#if @small}}
-                <circle
-                  class='cds--loading__background'
-                  cx='0'
-                  cy='0'
-                  r='37.5'
-                />
-              {{/if}}
-              <circle class='cds--loading__stroke' cx='0' cy='0' r='37.5' />
-            </svg>
-          </div>
-        </div>
-      {{else if @inline}}
+    {{#if this.defaultArgs.inline}}
+      {{#if this.defaultArgs.active}}
         <div
-          class='cds--inline-loading {{@classNames}}'
+          class='cds--inline-loading {{this.defaultArgs.classNames}}'
           aria-live='assertive'
           style='margin-left: 1rem; width: initial; display: inline-block;'
           ...attributes
@@ -69,43 +44,94 @@ export default class LoadingComponent extends Component<LoadingComponentSignatur
               aria-live='assertive'
               class='cds--loading cds--loading--small'
             >
-              <svg class='cds--loading__svg' viewBox='-75 -75 150 150'>
-                <title>
-                  {{@title}}
-                </title>
+              <svg
+                class='cds--loading__svg'
+                viewBox='0 0 100 100'
+                role='img'
+                aria-label={{this.defaultArgs.description}}
+              >
+                <title>{{this.defaultArgs.description}}</title>
                 <circle
                   class='cds--loading__background'
-                  cx='0'
-                  cy='0'
-                  r='37.5'
-                ></circle>
-                <circle class='cds--loading__stroke' cx='0' cy='0' r='37.5'>
-                </circle>
+                  cx='50%'
+                  cy='50%'
+                  r='42'
+                />
+                <circle class='cds--loading__stroke' cx='50%' cy='50%' r='42' />
               </svg>
             </div>
           </div>
           <div class='cds--inline-loading__text'>
-            {{this.defaultArgs.title}}
+            {{@description}}
           </div>
         </div>
-      {{else}}
-        <div data-loading class='{{@classNames}}' ...attributes>
+      {{/if}}
+    {{else if this.defaultArgs.withOverlay}}
+      <div
+        class='cds--loading-overlay
+          {{unless this.defaultArgs.active "cds--loading-overlay--stop"}}'
+      >
+        <div
+          aria-atomic='true'
+          aria-live={{if this.defaultArgs.active 'assertive' 'off'}}
+          class='cds--loading
+            {{if this.defaultArgs.small "cds--loading--small"}}
+            {{unless this.defaultArgs.active "cds--loading--stop"}}
+            {{this.defaultArgs.classNames}}'
+          ...attributes
+        >
           <svg
-            class='cds--loading
-              {{if this.defaultArgs.small "cds--loading--small"}}
-              cds--loading__svg'
-            viewBox='-75 -75 150 150'
+            class='cds--loading__svg'
+            viewBox='0 0 100 100'
+            role='img'
+            aria-label={{this.defaultArgs.description}}
           >
-            <title>
-              {{@title}}
-            </title>
+            <title>{{this.defaultArgs.description}}</title>
             {{#if this.defaultArgs.small}}
-              <circle class='cds--loading__background' cx='0' cy='0' r='37.5' />
+              <circle
+                class='cds--loading__background'
+                cx='50%'
+                cy='50%'
+                r='42'
+              />
             {{/if}}
-            <circle class='cds--loading__stroke' cx='0' cy='0' r='37.5' />
+            <circle
+              class='cds--loading__stroke'
+              cx='50%'
+              cy='50%'
+              r={{if this.defaultArgs.small '42' '44'}}
+            />
           </svg>
         </div>
-      {{/if}}
+      </div>
+    {{else}}
+      <div
+        aria-atomic='true'
+        aria-live={{if this.defaultArgs.active 'assertive' 'off'}}
+        class='cds--loading
+          {{if this.defaultArgs.small "cds--loading--small"}}
+          {{unless this.defaultArgs.active "cds--loading--stop"}}
+          {{this.defaultArgs.classNames}}'
+        ...attributes
+      >
+        <svg
+          class='cds--loading__svg'
+          viewBox='0 0 100 100'
+          role='img'
+          aria-label={{this.defaultArgs.description}}
+        >
+          <title>{{this.defaultArgs.description}}</title>
+          {{#if this.defaultArgs.small}}
+            <circle class='cds--loading__background' cx='50%' cy='50%' r='42' />
+          {{/if}}
+          <circle
+            class='cds--loading__stroke'
+            cx='50%'
+            cy='50%'
+            r={{if this.defaultArgs.small '42' '44'}}
+          />
+        </svg>
+      </div>
     {{/if}}
   </template>
 }

--- a/carbon-components-ember/src/components/loading.gts
+++ b/carbon-components-ember/src/components/loading.gts
@@ -35,7 +35,7 @@ export default class LoadingComponent extends Component<LoadingComponentSignatur
         <div
           class='cds--inline-loading {{this.defaultArgs.classNames}}'
           aria-live='assertive'
-          style='margin-left: 1rem; width: initial; display: inline-block;'
+          style='margin-left: 1rem; width: initial; display: inline-flex; align-items: center;'
           ...attributes
         >
           <div class='cds--inline-loading__animation'>

--- a/docs-app/app/templates/2-components/loading.gjs.md
+++ b/docs-app/app/templates/2-components/loading.gjs.md
@@ -21,18 +21,18 @@ function showWithOverlay() {
 <template>
     <ThemeSupport />
     <p>loading</p>
-    <Loading @title='loading'/>
+    <Loading @withOverlay={{false}} @description='loading' />
     <br>
-    <Loading @inline={{true}} @title='inline loading' />
+    <Loading @inline={{true}} @description='inline loading' />
     <br>
     <p>loading active=false</p>
-    <Loading @active={{false}} />
+    <Loading @withOverlay={{false}} @active={{false}} />
     <br>
     <p>loading small=false</p>
-    <Loading @small={{true}} />
+    <Loading @withOverlay={{false}} @small={{true}} />
     <br>
     {{#if showOver.current}}
-        <Loading @overlay={{true}} />
+        <Loading @withOverlay={{true}} />
     {{/if}}
     <br>
     <Button

--- a/test-app/tests/components/loading-test.gts
+++ b/test-app/tests/components/loading-test.gts
@@ -1,0 +1,92 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import Loading from 'carbon-components-ember/components/loading';
+
+module('Integration | Component | Loading', (hooks) => {
+  setupRenderingTest(hooks);
+
+  test('renders active by default without an overlay wrapper class', async function (assert) {
+    await render(<template><Loading @withOverlay={{false}} /></template>);
+
+    assert.dom('.cds--loading').exists();
+    assert.dom('.cds--loading').hasAttribute('aria-live', 'assertive');
+    assert.dom('.cds--loading').doesNotHaveClass('cds--loading--stop');
+    assert.dom('.cds--loading-overlay').doesNotExist();
+  });
+
+  test('@active=false stops the spinner without hiding it', async function (assert) {
+    await render(
+      <template><Loading @withOverlay={{false}} @active={{false}} /></template>,
+    );
+
+    assert.dom('.cds--loading').exists();
+    assert.dom('.cds--loading').hasClass('cds--loading--stop');
+    assert.dom('.cds--loading').hasAttribute('aria-live', 'off');
+  });
+
+  test('@small renders the small variant with a background circle', async function (assert) {
+    await render(
+      <template><Loading @withOverlay={{false}} @small={{true}} /></template>,
+    );
+
+    assert.dom('.cds--loading').hasClass('cds--loading--small');
+    assert.dom('.cds--loading__background').exists();
+  });
+
+  test('@description sets the svg title and aria-label', async function (assert) {
+    await render(
+      <template>
+        <Loading @withOverlay={{false}} @description='fetching data' />
+      </template>,
+    );
+
+    assert.dom('.cds--loading__svg title').hasText('fetching data');
+    assert.dom('.cds--loading__svg').hasAttribute('aria-label', 'fetching data');
+  });
+
+  test('@withOverlay defaults to true and wraps in a full-page overlay', async function (assert) {
+    await render(<template><Loading /></template>);
+
+    assert.dom('.cds--loading-overlay').exists();
+    assert.dom('.cds--loading-overlay .cds--loading').exists();
+  });
+
+  test('@withOverlay + @active=false hides the overlay', async function (assert) {
+    await render(
+      <template><Loading @active={{false}} /></template>,
+    );
+
+    assert.dom('.cds--loading-overlay').hasClass('cds--loading-overlay--stop');
+  });
+
+  test('@inline renders the inline loading variant with text', async function (assert) {
+    await render(
+      <template>
+        <Loading @inline={{true}} @description='saving' />
+      </template>,
+    );
+
+    assert.dom('.cds--inline-loading').exists();
+    assert.dom('.cds--inline-loading__text').hasText('saving');
+  });
+
+  test('@inline without @description does not leak the default description as visible text', async function (assert) {
+    await render(<template><Loading @inline={{true}} /></template>);
+
+    assert.dom('.cds--inline-loading__text').hasText('');
+    assert
+      .dom('.cds--inline-loading .cds--loading__svg')
+      .hasAttribute('aria-label', 'loading');
+  });
+
+  test('@inline + @active=false renders nothing', async function (assert) {
+    await render(
+      <template>
+        <Loading @inline={{true}} @active={{false}} />
+      </template>,
+    );
+
+    assert.dom('.cds--inline-loading').doesNotExist();
+  });
+});

--- a/test-app/tests/components/loading-test.gts
+++ b/test-app/tests/components/loading-test.gts
@@ -1,6 +1,6 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render } from '@ember/test-helpers';
+import { find, render } from '@ember/test-helpers';
 import Loading from 'carbon-components-ember/components/loading';
 
 module('Integration | Component | Loading', (hooks) => {
@@ -69,6 +69,11 @@ module('Integration | Component | Loading', (hooks) => {
 
     assert.dom('.cds--inline-loading').exists();
     assert.dom('.cds--inline-loading__text').hasText('saving');
+    assert.strictEqual(
+      getComputedStyle(find('.cds--inline-loading') as Element).display,
+      'inline-flex',
+      'the animation and text lay out side-by-side instead of stacking',
+    );
   });
 
   test('@inline without @description does not leak the default description as visible text', async function (assert) {


### PR DESCRIPTION
Closes #783

## What changed

Investigated the full React `Loading` API (`Loading.tsx` + `Loading.stories.js`) and found the Ember component had drifted well beyond the single "add Storybook controls" commit the issue flagged:

- **`title` → `description`** — the old `title` arg was typed as `boolean` but used as a string; renamed/retyped to `description` matching React's `description` prop, default `'loading'`, applied to the svg `<title>` and `aria-label`.
- **`overlay` → `withOverlay`**, default flipped `false` → `true` to match `carbon-react`'s actual component default (`withOverlay = true`). The React Storybook `Default` story overrides this to `false` just for display purposes — the component's real default is `true`. **This is a behavior change**: a bare `<Loading />` now renders as a full-viewport overlay by default instead of a small inline spinner. Consumers relying on the old bare default need `@withOverlay={{false}}`.
- **`@active={{false}}` no longer removes the component from the DOM.** React keeps it mounted and switches to a "stopped" CSS state (`cds--loading--stop` / `cds--loading-overlay--stop`) with `aria-live="off"`; the overlay variant's own CSS (`display: none`) is what visually hides it, not a template `{{#if}}`.
- Added `aria-atomic`, `aria-live`, `role="img"`, `aria-label` to match React's accessibility markup, and updated the svg `viewBox`/circle geometry to React's current `0 0 100 100` / `r=42|44` values (small-variant circles were previously oversized relative to the small container).

`inline` and `classNames` are pre-existing extensions with no equivalent in `carbon-react`'s `Loading` (`InlineLoading` is tracked separately in `.parity-check-data.json` as a missing component, not covered by this issue). Their behavior — including fully hiding when `@active` is false — is preserved unchanged, since `Button`, `Icon`, and `DataTable`'s search input all depend on that exact behavior internally.

## Test plan
- [x] `pnpm build` succeeds (types + rollup)
- [x] `glint` reports no errors for `loading.gts`
- [x] Full `test-app` suite: 543/543 passing, including `Button`, `IconIndicator`, and `DataTable` tests that render `Loading` internally
- [x] New `loading-test.gts` covers: default (no overlay), `@active=false` (stop, not hide), `@small`, `@description`, `@withOverlay` default-true, `@withOverlay` + `@active=false` (hidden via CSS), `@inline`, and `@inline` with no `@description` (verifies the default description text does not leak into the visible inline text node)
- [x] Docs live-preview example updated to the new arg names and covers every combination from the single React `Default` story (active, small, description, withOverlay)