### PR TITLE
feat: align CopyButton with React's public API

### DIFF
--- a/.parity-check-data.json
+++ b/.parity-check-data.json
@@ -377,7 +377,7 @@
     },
     "CopyButton": {
       "lastCheckedCommit": "5102bd860864c2580048183ffaf50d1ffd4400b5",
-      "lastSyncedCommit": "N/A",
+      "lastSyncedCommit": "188d23202ec1092322dee92cf0df9d9958224ae4",
       "hasChanges": false,
       "changeCount": 0,
       "lastUpdate": null

--- a/carbon-components-ember/src/components/code-snippet.gts
+++ b/carbon-components-ember/src/components/code-snippet.gts
@@ -55,11 +55,7 @@ export default class CarbonCodeSnippet extends Component<CarbonCodeSnippetSignat
             {{~yield~}}
           </PreCode>
         </div>
-        <span
-          class='cds--popover-container cds--popover--caret cds--popover--high-contrast cds--popover--bottom cds--tooltip cds--icon-tooltip'
-        >
-          <CopyButton @targetElement={{this.carbonElement}} />
-        </span>
+        <CopyButton @targetElement={{this.carbonElement}} />
       </div>
     {{/if}}
     {{#if (eq @type 'multiline')}}
@@ -83,11 +79,7 @@ export default class CarbonCodeSnippet extends Component<CarbonCodeSnippetSignat
           </PreCode>
         </div>
         <div class='cds--snippet__overflow-indicator--right'></div>
-        <span
-          class='cds--popover-container cds--popover--caret cds--popover--high-contrast cds--popover--bottom cds--tooltip cds--icon-tooltip'
-        >
-          <CopyButton @targetElement={{this.codeElement}} />
-        </span>
+        <CopyButton @targetElement={{this.codeElement}} />
         <button
           {{on 'click' (fn (set this 'expanded') (not this.expanded))}}
           class='cds--btn cds--btn--ghost cds--btn--sm cds--snippet-btn--expand'

--- a/carbon-components-ember/src/components/copy-button.gts
+++ b/carbon-components-ember/src/components/copy-button.gts
@@ -1,116 +1,48 @@
 import Component from '@glimmer/component';
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
-import didInsert from '@ember/render-modifiers/modifiers/did-insert';
-import Tooltip from './-private/tooltip.gts';
+import { guidFor } from '@ember/object/internals';
+import { on } from '@ember/modifier';
+import { modifier as eModifier } from 'ember-modifier';
+import { task, timeout } from 'ember-concurrency';
+import Popover, { PopoverContent, type PopoverAlignment } from './popover.gts';
 import Button from '../components/button.gts';
-import or from '../helpers/or.ts';
 
 export type Args = {
   targetElementId?: string;
   targetElement?: Element;
   inline?: boolean;
+  align?: PopoverAlignment;
+  autoAlign?: boolean;
+  disabled?: boolean;
+  feedback?: string;
+  feedbackTimeout?: number;
+  iconDescription?: string;
+  onClick?: () => void;
 };
 
 export interface CarbonCopyButtonSignature {
   Args: Args;
-  Element: null;
+  Element: HTMLButtonElement;
   Blocks: {
     default: [];
   };
 }
 
-export default class CarbonCopyButton extends Component<CarbonCopyButtonSignature> {
-  <template>
-    {{#if (or @targetElement @targetElementId)}}
-      <Tooltip @isShown={{this.didCopy}}>
-        <:trigger as |reference|>
-          <Button
-            data-copy-btn
-            aria-label='Copy code'
-            tabindex='0'
-            @type='primary'
-            @size='md'
-            @iconOnly={{true}}
-            @onClick={{this.copyToClipboard}}
-            class='cds--copy
-              {{if @inline "cds--snippet cds--snippet--inline" "cds--copy-btn"}}'
-            {{reference}}
-            {{didInsert this.loadCarbonComponent}}
-          >
-            {{#if (has-block)}}
-              <code>
-                {{~yield~}}
-              </code>
-            {{/if}}
-            {{#unless @inline}}
-              <svg
-                class='cds--snippet__icon'
-                xmlns='http://www.w3.org/2000/svg'
-                width='16'
-                height='16'
-                viewBox='0 0 16 16'
-              >
-                <path d='M1 10H0V2C0 .9.9 0 2 0h8v1H2c-.6 0-1 .5-1 1v8z' />
-                <path
-                  d='M11 4.2V8h3.8L11 4.2zM15 9h-4c-.6 0-1-.4-1-1V4H4.5c-.3 0-.5.2-.5.5v10c0 .3.2.5.5.5h10c.3 0 .5-.2.5-.5V9zm-4-6c.1 0 .3.1.4.1l4.5 4.5c0
-                  .1.1.3.1.4v6.5c0 .8-.7 1.5-1.5 1.5h-10c-.8 0-1.5-.7-1.5-1.5v-10C3 3.7 3.7 3 4.5 3H11z'
-                />
-              </svg>
-            {{/unless}}
-          </Button>
-        </:trigger>
-        <:content>
-          {{if this.didCopy 'Copied!' 'Copy to clipboard'}}
-        </:content>
-      </Tooltip>
-    {{else}}
-      <Tooltip @isShown={{this.didCopy}}>
-        <:trigger as |reference|>
-          <Button
-            data-copy-btn
-            aria-label='Copy code'
-            tabindex='0'
-            @type='primary'
-            @size='md'
-            @iconOnly={{true}}
-            @onClick={{this.copyToClipboard}}
-            class='cds--copy
-              {{if @inline "cds--snippet cds--snippet--inline" "cds--copy-btn"}}'
-            {{reference}}
-            {{didInsert this.loadCarbonComponent}}
-          >
-            {{~#if (has-block)}}
-              <code>
-                {{~yield~}}
-              </code>
-            {{/if}}
-            {{#unless @inline}}
-              <svg
-                class='cds--snippet__icon'
-                xmlns='http://www.w3.org/2000/svg'
-                width='16'
-                height='16'
-                viewBox='0 0 16 16'
-              >
-                <path d='M1 10H0V2C0 .9.9 0 2 0h8v1H2c-.6 0-1 .5-1 1v8z' />
-                <path
-                  d='M11 4.2V8h3.8L11 4.2zM15 9h-4c-.6 0-1-.4-1-1V4H4.5c-.3 0-.5.2-.5.5v10c0
-                  .3.2.5.5.5h10c.3 0 .5-.2.5-.5V9zm-4-6c.1 0 .3.1.4.1l4.5 4.5c0 .1.1.3.1.4v6.5c0 .8-.7 1.5-1.5 1.5h-10c-.8 0-1.5-.7-1.5-1.5v-10C3 3.7 3.7 3 4.5 3H11z'
-                />
-              </svg>
-            {{/unless}}
-          </Button>
-        </:trigger>
-        <:content>
-          {{if this.didCopy 'Copied!' 'Copy to clipboard'}}
-        </:content>
-      </Tooltip>
-    {{/if}}
-  </template>
+const captureElement = eModifier<{
+  Element: HTMLElement;
+  Args: { Named: { onInsert: (element: HTMLElement) => void } };
+}>((element, _positional, { onInsert }) => {
+  onInsert(element);
+});
 
-  carbonElement: any;
+export default class CarbonCopyButton extends Component<CarbonCopyButtonSignature> {
   @tracked didCopy: boolean = false;
+  @tracked isHovered: boolean = false;
+  carbonElement?: HTMLElement;
+
+  tooltipId = `${guidFor(this)}-copy-btn-tooltip`;
+
   get options() {
     return {
       targetElement: this.args.targetElement,
@@ -118,10 +50,43 @@ export default class CarbonCopyButton extends Component<CarbonCopyButtonSignatur
     };
   }
 
-  @action
-  loadCarbonComponent(carbonElement: HTMLElement) {
-    this.carbonElement = carbonElement;
+  get align(): PopoverAlignment {
+    return this.args.align ?? 'bottom';
   }
+
+  get feedback() {
+    return this.args.feedback ?? 'Copied!';
+  }
+
+  get iconDescription() {
+    return this.args.iconDescription ?? 'Copy to clipboard';
+  }
+
+  get isOpen() {
+    return this.didCopy || this.isHovered;
+  }
+
+  get label() {
+    return this.didCopy ? this.feedback : this.iconDescription;
+  }
+
+  show = () => {
+    this.isHovered = true;
+  };
+
+  hide = () => {
+    this.isHovered = false;
+  };
+
+  @action
+  captureCarbonElement(element: HTMLElement) {
+    this.carbonElement = element;
+  }
+
+  hideFeedback = task({ restartable: true }, async () => {
+    await timeout(this.args.feedbackTimeout ?? 2000);
+    this.didCopy = false;
+  });
 
   @action
   copyToClipboard() {
@@ -154,8 +119,66 @@ export default class CarbonCopyButton extends Component<CarbonCopyButtonSignatur
       document.getSelection()!.addRange(selected); // Restore the original selection
     }
     this.didCopy = true;
-    setTimeout(() => {
-      this.didCopy = false;
-    }, 3000);
+    void this.hideFeedback.perform();
+    this.args.onClick?.();
   }
+
+  <template>
+    <Popover
+      @open={{this.isOpen}}
+      @align={{this.align}}
+      @autoAlign={{@autoAlign}}
+      @highContrast={{true}}
+      class='cds--tooltip cds--icon-tooltip'
+    >
+      <Button
+        data-copy-btn
+        aria-label={{this.label}}
+        aria-describedby={{this.tooltipId}}
+        tabindex='0'
+        @type='primary'
+        @size='md'
+        @iconOnly={{true}}
+        @disabled={{@disabled}}
+        @onClick={{this.copyToClipboard}}
+        class='cds--copy
+          {{if @inline "cds--snippet cds--snippet--inline" "cds--copy-btn"}}'
+        ...attributes
+        {{on 'mouseenter' this.show}}
+        {{on 'mouseleave' this.hide}}
+        {{on 'focusin' this.show}}
+        {{on 'focusout' this.hide}}
+        {{captureElement onInsert=this.captureCarbonElement}}
+      >
+        {{#if (has-block)}}
+          <code>
+            {{~yield~}}
+          </code>
+        {{/if}}
+        {{#unless @inline}}
+          <svg
+            class='cds--snippet__icon'
+            xmlns='http://www.w3.org/2000/svg'
+            width='16'
+            height='16'
+            viewBox='0 0 16 16'
+          >
+            <path d='M1 10H0V2C0 .9.9 0 2 0h8v1H2c-.6 0-1 .5-1 1v8z' />
+            <path
+              d='M11 4.2V8h3.8L11 4.2zM15 9h-4c-.6 0-1-.4-1-1V4H4.5c-.3 0-.5.2-.5.5v10c0 .3.2.5.5.5h10c.3 0 .5-.2.5-.5V9zm-4-6c.1 0 .3.1.4.1l4.5 4.5c0
+              .1.1.3.1.4v6.5c0 .8-.7 1.5-1.5 1.5h-10c-.8 0-1.5-.7-1.5-1.5v-10C3 3.7 3.7 3 4.5 3H11z'
+            />
+          </svg>
+        {{/unless}}
+      </Button>
+      <PopoverContent
+        id={{this.tooltipId}}
+        role='tooltip'
+        class='cds--tooltip-content'
+        aria-hidden={{if this.isOpen 'false' 'true'}}
+      >
+        {{this.label}}
+      </PopoverContent>
+    </Popover>
+  </template>
 }

--- a/carbon-components-ember/src/components/copy-button.gts
+++ b/carbon-components-ember/src/components/copy-button.gts
@@ -151,7 +151,7 @@ export default class CarbonCopyButton extends Component<CarbonCopyButtonSignatur
         {{captureElement onInsert=this.captureCarbonElement}}
       >
         {{#if (has-block)}}
-          <code>
+          <code class={{unless @inline 'cds--visually-hidden'}}>
             {{~yield~}}
           </code>
         {{/if}}

--- a/docs-app/app/templates/2-components/copy-button.gjs.md
+++ b/docs-app/app/templates/2-components/copy-button.gjs.md
@@ -1,0 +1,80 @@
+<ThemeSwitcher />
+
+# Copy Button
+
+`CopyButton` is an icon-only button that copies text to the clipboard and
+shows a "Copied!" tooltip as feedback. It is used internally by `CodeSnippet`,
+but can also be used on its own — pass the text to copy as the block content,
+or point it at another element via `@targetElement`/`@targetElementId`.
+
+```gjs live preview
+import { CopyButton } from 'carbon-components-ember/components';
+import { ThemeSupport } from 'docs-support';
+
+<template>
+  <ThemeSupport />
+  <br />
+
+  <CopyButton>console.log('hello world');</CopyButton>
+</template>
+```
+
+## Custom feedback and icon description
+
+`@iconDescription` sets the accessible name and tooltip label shown before a
+copy, defaulting to `'Copy to clipboard'`. `@feedback` sets the tooltip label
+shown after a copy, defaulting to `'Copied!'`, and `@feedbackTimeout`
+controls how long (in ms) it stays visible before reverting, defaulting to
+`2000`.
+
+```gjs live preview
+import { CopyButton } from 'carbon-components-ember/components';
+import { ThemeSupport } from 'docs-support';
+
+<template>
+  <ThemeSupport />
+  <br />
+
+  <CopyButton
+    @iconDescription='Duplicate'
+    @feedback='Duplicated!'
+    @feedbackTimeout={{1000}}
+  >console.log('hello world');</CopyButton>
+</template>
+```
+
+## Alignment and disabled state
+
+`@align` and `@autoAlign` behave the same as on `Popover`/`Tooltip`. Passing
+`@disabled={{true}}` disables the button.
+
+```gjs live preview
+import { CopyButton } from 'carbon-components-ember/components';
+import { ThemeSupport } from 'docs-support';
+
+<template>
+  <ThemeSupport />
+  <br />
+
+  <CopyButton @align='top'>console.log('hello world');</CopyButton>
+  <CopyButton @disabled={{true}}>console.log('hello world');</CopyButton>
+</template>
+```
+
+## API Reference
+
+<details>
+<summary><h3>CopyButton</h3></summary>
+
+```gjs live no-shadow
+import { ComponentSignature } from 'kolay';
+
+<template>
+  <ComponentSignature
+    @package="carbon-components-ember"
+    @module='declarations/components/copy-button'
+    @name='default'
+  />
+</template>
+```
+</details>

--- a/test-app/tests/components/copy-button-test.gts
+++ b/test-app/tests/components/copy-button-test.gts
@@ -1,0 +1,120 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render, find, waitUntil, click, rerender } from '@ember/test-helpers';
+import CopyButton from 'carbon-components-ember/components/copy-button';
+
+module('Integration | Component | CopyButton', (hooks) => {
+  setupRenderingTest(hooks);
+
+  test('should render with the default icon description', async function (assert) {
+    await render(<template><CopyButton>some code</CopyButton></template>);
+    await waitUntil(() => find('[data-copy-btn]'));
+
+    assert.dom('[data-copy-btn]').hasAttribute('aria-label', 'Copy to clipboard');
+    assert.dom('[data-copy-btn] code').hasText('some code');
+  });
+
+  test('should copy the block content to the clipboard and show feedback on click', async function (assert) {
+    await render(<template><CopyButton>copy me</CopyButton></template>);
+    await waitUntil(() => find('[data-copy-btn]'));
+
+    // Dispatch a raw click and only wait for the DOM to re-render, rather
+    // than the `click()` test helper's full `settled()`, which would also
+    // wait out the feedback timeout task and observe the reverted state.
+    find('[data-copy-btn]')!.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    await rerender();
+
+    assert.dom('[data-copy-btn]').hasAttribute('aria-label', 'Copied!');
+    assert
+      .dom(`#${find('[data-copy-btn]')!.getAttribute('aria-describedby')}`)
+      .hasText('Copied!');
+  });
+
+  test('should support a custom feedback message', async function (assert) {
+    await render(
+      <template>
+        <CopyButton @feedback='Done!'>copy me</CopyButton>
+      </template>,
+    );
+    await waitUntil(() => find('[data-copy-btn]'));
+
+    find('[data-copy-btn]')!.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    await rerender();
+
+    assert.dom('[data-copy-btn]').hasAttribute('aria-label', 'Done!');
+  });
+
+  test('should support a custom iconDescription', async function (assert) {
+    await render(
+      <template>
+        <CopyButton @iconDescription='Duplicate'>copy me</CopyButton>
+      </template>,
+    );
+    await waitUntil(() => find('[data-copy-btn]'));
+
+    assert.dom('[data-copy-btn]').hasAttribute('aria-label', 'Duplicate');
+  });
+
+  test('should call the onClick handler when clicked', async function (assert) {
+    let called = 0;
+    const onClick = () => called++;
+
+    await render(
+      <template>
+        <CopyButton @onClick={{onClick}}>copy me</CopyButton>
+      </template>,
+    );
+    await waitUntil(() => find('[data-copy-btn]'));
+
+    await click('[data-copy-btn]');
+
+    assert.strictEqual(called, 1);
+  });
+
+  test('should support the disabled arg', async function (assert) {
+    await render(
+      <template>
+        <CopyButton @disabled={{true}}>copy me</CopyButton>
+      </template>,
+    );
+    await waitUntil(() => find('[data-copy-btn]'));
+
+    assert.dom('[data-copy-btn]').isDisabled();
+  });
+
+  test('should support the align arg', async function (assert) {
+    await render(
+      <template>
+        <CopyButton @align='top'>copy me</CopyButton>
+      </template>,
+    );
+    await waitUntil(() => find('[data-copy-btn]'));
+
+    assert.dom('.cds--popover-container').hasClass('cds--popover--top');
+  });
+
+  test('should copy from a targetElement', async function (assert) {
+    await render(
+      <template>
+        <pre id='target'>target content</pre>
+        <CopyButton @targetElementId='target' />
+      </template>,
+    );
+    await waitUntil(() => find('[data-copy-btn]'));
+
+    find('[data-copy-btn]')!.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    await rerender();
+
+    assert.dom('[data-copy-btn]').hasAttribute('aria-label', 'Copied!');
+  });
+
+  test('should render inline snippet classes', async function (assert) {
+    await render(
+      <template><CopyButton @inline={{true}}>inline code</CopyButton></template>,
+    );
+    await waitUntil(() => find('[data-copy-btn]'));
+
+    assert.dom('[data-copy-btn]').hasClass('cds--snippet--inline');
+    assert.dom('[data-copy-btn] svg').doesNotExist();
+  });
+});

--- a/test-app/tests/components/copy-button-test.gts
+++ b/test-app/tests/components/copy-button-test.gts
@@ -14,6 +14,14 @@ module('Integration | Component | CopyButton', (hooks) => {
     assert.dom('[data-copy-btn] code').hasText('some code');
   });
 
+  test('without @inline, block content is visually hidden behind the icon', async function (assert) {
+    await render(<template><CopyButton>some code</CopyButton></template>);
+    await waitUntil(() => find('[data-copy-btn]'));
+
+    assert.dom('[data-copy-btn] code').hasClass('cds--visually-hidden');
+    assert.dom('[data-copy-btn] svg').exists();
+  });
+
   test('should copy the block content to the clipboard and show feedback on click', async function (assert) {
     await render(<template><CopyButton>copy me</CopyButton></template>);
     await waitUntil(() => find('[data-copy-btn]'));


### PR DESCRIPTION
Closes #751

## What changed

`CopyButton` only exposed `targetElementId`/`targetElement`/`inline` and hardcoded its tooltip text, `feedbackTimeout` (3000ms instead of React's 2000ms) and `iconDescription` default ("Copy code" instead of React's "Copy to clipboard"). It was missing `align`, `autoAlign`, `disabled`, `feedback`, `feedbackTimeout`, `iconDescription` and `onClick`, all present on React's `CopyButton`.

- Added the missing args, matching React's `CopyButton.tsx`/`Copy.tsx` defaults.
- Rebuilt the tooltip on the addon's own `Popover`/`PopoverContent` (`components/popover.gts`), which already implements Carbon's full alignment set including the deprecated→new alignment mapping, instead of the private floating-ui-based `-private/tooltip.gts`. This is the pattern already used by `IconIndicator`'s compact mode.
- Replaced the bare `setTimeout` feedback-hide timer with a restartable `ember-concurrency` task, and the `did-insert` element capture with a functional `ember-modifier`, per AGENTS.md.
- `CodeSnippet` previously wrapped `<CopyButton>` in a hand-rolled `<span class="cds--popover-container ...">` — removed, since `CopyButton` now renders its own popover container with the same classes.
- Kept `targetElementId`/`targetElement`/`inline` as Ember-side conveniences (React's `CopyButton` doesn't do the actual clipboard write itself — that's left to the consumer's `onClick` — but this addon's existing `CopyButton` already performs the copy, and is consumed internally by `CodeSnippet`, so removing that would be a breaking change with no React equivalent to replace it).

## Testing

- `pnpm build` passes.
- Added `test-app/tests/components/copy-button-test.gts` covering the default render, copy + feedback tooltip, custom `feedback`/`iconDescription`, `onClick`, `disabled`, `align`, `targetElementId`, and `inline`. Full suite (543 tests) passes.
- Added `docs-app/app/templates/2-components/copy-button.gjs.md` with live-preview examples (default, custom feedback, alignment/disabled).