### PR TITLE
chore: mark SkeletonPlaceholder as synced

### DIFF
--- a/.parity-check-data.json
+++ b/.parity-check-data.json
@@ -496,7 +496,7 @@
     },
     "SkeletonPlaceholder": {
       "lastCheckedCommit": "5102bd860864c2580048183ffaf50d1ffd4400b5",
-      "lastSyncedCommit": "5102bd860864c2580048183ffaf50d1ffd4400b5",
+      "lastSyncedCommit": "188d23202ec1092322dee92cf0df9d9958224ae4",
       "hasChanges": false,
       "changeCount": 0,
       "lastUpdate": null


### PR DESCRIPTION
Closes #788 — verified SkeletonPlaceholder already matches the React implementation, no changes needed.

The only upstream change since last sync was e6aae2f (fix(Skeleton): add Storybook controls #22982), which only adds `argTypes` for Storybook range controls (height/width) — no change to the component's props, API, or behavior. The React `SkeletonPlaceholder` still only accepts `className` plus native div attributes via spread.

The Ember implementation (`carbon-components-ember/src/components/skeleton-placeholder.gts`) already matches:
- renders a single `<div class="cds--skeleton__placeholder" ...attributes>`
- `...attributes` merges consumer-supplied `class`, mirroring React's `classNames` merge — covered by existing test
- tests and docs (`docs-app/app/templates/2-components/skeleton/placeholder.gjs.md`) already exist and are current

No code changes were required.