### PR TITLE
chore: mark Link as synced

### DIFF
--- a/.parity-check-data.json
+++ b/.parity-check-data.json
@@ -706,7 +706,7 @@
     },
     "Link": {
       "lastCheckedCommit": "5102bd860864c2580048183ffaf50d1ffd4400b5",
-      "lastSyncedCommit": "a57cf8a896fe3fe09c5ab27648cd58947f37360a",
+      "lastSyncedCommit": "188d23202ec1092322dee92cf0df9d9958224ae4",
       "hasChanges": false,
       "changeCount": 0,
       "lastUpdate": null


### PR DESCRIPTION
Closes #782 — verified Link already matches the React implementation, no changes needed.

The two flagged upstream commits are pure SCSS fixes in `@carbon/styles` (visited-link selector cleanup, and a `display` property revert on the base link / new `cds--link--icon` display rule), already present in the `@carbon/styles@1.113.0` dependency this addon consumes. The one JS-side change (adding `cds--link--icon` when `renderIcon` is set) was already implemented in `link.gts`.

Full prop/story parity confirmed against current React `Link.tsx`/`Link.stories.js` — all props and all three stories (Default, Inline, PairedWithIcon) are already covered.