### PR TITLE
chore: mark SkeletonIcon as synced

### DIFF
--- a/.parity-check-data.json
+++ b/.parity-check-data.json
@@ -594,7 +594,7 @@
     },
     "SkeletonIcon": {
       "lastCheckedCommit": "5102bd860864c2580048183ffaf50d1ffd4400b5",
-      "lastSyncedCommit": "5102bd860864c2580048183ffaf50d1ffd4400b5",
+      "lastSyncedCommit": "188d23202ec1092322dee92cf0df9d9958224ae4",
       "hasChanges": false,
       "changeCount": 0,
       "lastUpdate": null


### PR DESCRIPTION
Closes #787 — verified SkeletonIcon already matches the React implementation, no changes needed.

The only upstream change since last sync was e6aae2f (fix(Skeleton): add Storybook controls #22982), which only adds Storybook `argTypes` (className text control, and a `size` range control used solely to drive inline style in the story) and consolidates the `Default` story from two static examples into one args-driven example. It does not add, rename, or change any real component prop — `SkeletonIconProps` still only declares `className?: string`, with `style`/other native div attributes passed through via rest-prop spread.

The Ember implementation (`carbon-components-ember/src/components/skeleton-icon.gts`) already matches:
- renders a single `<div class="cds--icon--skeleton" ...attributes>`
- `...attributes` covers `class` and inline `style`/sizing, mirroring React's className + rest-prop spread — covered by existing tests (`test-app/tests/components/skeleton-icon-test.gts`)
- docs (`docs-app/app/templates/2-components/skeleton/icon.gjs.md`) already demonstrate both a default and a custom-sized instance, matching the story's `size` control example

No code changes were required.