### PR TITLE
feat(scripts): track carbon-ai-chat in parity-check alongside Carbon React

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -18,6 +18,7 @@ independently (see the `SOURCES` array at the top of the script):
 cd scripts
 npm install
 npm run check-parity                              # all sources, report-only unless CREATE_ISSUES=true
+node parity-check.mjs --source carbon-ai-chat                          # run just one source
 node parity-check.mjs --source carbon-ai-chat --mark-synced Launcher   # source-scoped CLI flags
 ```
 
@@ -35,7 +36,7 @@ node parity-check.mjs --source carbon-ai-chat --mark-synced Launcher   # source-
 - `CREATE_ISSUES` - Set to 'true' to automatically create issues (default: false; also requires the target source's `createIssues: true`)
 
 **CLI flags:**
-- `--source <id>` - scope `--mark-synced`/etc. to a source (default: `react`); valid ids are the `id` fields in `SOURCES`
+- `--source <id>` - scope the run to a single source: the main fetch/compare/report/issue-creation pipeline, as well as `--mark-synced` (default source for that flag: `react`); valid ids are the `id` fields in `SOURCES`. Omit it to run every configured source.
 - `--mark-synced Name1,Name2` / `--exclude Name --reason "..."` / `--include Name` / `--list-exclusions` - unchanged, see below (exclusions are a single flat list shared across sources, since upstream naming conventions don't currently collide - PascalCase React directories vs. kebab-case carbon-ai-chat ones)
 
 ### fix-parity-issue.sh

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -6,27 +6,37 @@ This directory contains utility scripts for maintaining the carbon-components-em
 
 ### parity-check.mjs
 
-Automated script that compares carbon-components-ember with Carbon React to identify missing components.
+Automated script that compares carbon-components-ember with one or more upstream
+Carbon repositories to identify missing components. It tracks multiple **sources**
+independently (see the `SOURCES` array at the top of the script):
+
+- `react` - Carbon React (`carbon-design-system/carbon`, `packages/react/src/components`). Issue creation enabled.
+- `carbon-ai-chat` - Carbon AI Chat (`carbon-design-system/carbon-ai-chat`, `packages/ai-chat-components/src/components` - the reusable Lit widget library, i.e. the actual Ember port target, not the React application internals or the web-component shell). Issue creation is **disabled** for this source until the first Ember component under this namespace lands - with zero components implemented so far, every upstream component would otherwise show up as "missing" and flood the issue tracker on the first run. Flip `createIssues: true` for this source once that changes.
 
 **Usage:**
 ```bash
 cd scripts
 npm install
-npm run check-parity
+npm run check-parity                              # all sources, report-only unless CREATE_ISSUES=true
+node parity-check.mjs --source carbon-ai-chat --mark-synced Launcher   # source-scoped CLI flags
 ```
 
 **Features:**
-- Fetches component list from Carbon React GitHub
-- Compares with Ember implementation
-- Generates parity report (PARITY_REPORT.md)
-- **Tracks commit SHAs** to detect component updates
-- **Detects outdated components** when React components change
-- Tracks per-component metadata (.parity-check-data.json)
-- Can create GitHub issues for missing and outdated components
+- Fetches each source's component list from its GitHub repo
+- Compares with Ember implementation (shared `carbon-components-ember/src/components/index.ts` export list across all sources)
+- Generates one combined parity report with a section per source (PARITY_REPORT.md)
+- **Tracks commit SHAs** per source to detect component updates
+- **Detects outdated components** when upstream components change
+- Tracks per-source, per-component metadata (`.parity-check-data.json`'s `sources.<id>` object). The legacy top-level `components`/`componentMetadata` fields are kept in sync with the `react` source for backward compatibility.
+- Can create GitHub issues for missing and outdated components, gated by both the global `CREATE_ISSUES`/`--create-issues` flag and each source's own `createIssues` setting
 
 **Environment Variables:**
 - `GITHUB_TOKEN` - GitHub personal access token (required for API access)
-- `CREATE_ISSUES` - Set to 'true' to automatically create issues (default: false)
+- `CREATE_ISSUES` - Set to 'true' to automatically create issues (default: false; also requires the target source's `createIssues: true`)
+
+**CLI flags:**
+- `--source <id>` - scope `--mark-synced`/etc. to a source (default: `react`); valid ids are the `id` fields in `SOURCES`
+- `--mark-synced Name1,Name2` / `--exclude Name --reason "..."` / `--include Name` / `--list-exclusions` - unchanged, see below (exclusions are a single flat list shared across sources, since upstream naming conventions don't currently collide - PascalCase React directories vs. kebab-case carbon-ai-chat ones)
 
 ### fix-parity-issue.sh
 

--- a/scripts/parity-check.mjs
+++ b/scripts/parity-check.mjs
@@ -62,6 +62,9 @@ const SOURCES = [
     // far), so "components exported from Ember but not in this source"
     // is a meaningful signal.
     trackExtra: true,
+    // React's upstream directory names are already PascalCase and match
+    // the Ember export names 1:1.
+    nameToEmberExport: (name) => name,
   },
   {
     id: 'carbon-ai-chat',
@@ -87,6 +90,9 @@ const SOURCES = [
     // meaningless noise, not a real signal. Skip it until this source has
     // its own implemented components to actually compare against.
     trackExtra: false,
+    // Upstream directory names are kebab-case (e.g. "chat-shell"); the
+    // Ember port exports them as PascalCase (e.g. "ChatShell").
+    nameToEmberExport: kebabToPascalCase,
   },
 ];
 
@@ -96,6 +102,18 @@ function getSource(id) {
     throw new Error(`Unknown parity source "${id}". Known sources: ${SOURCES.map((s) => s.id).join(', ')}`);
   }
   return source;
+}
+
+/**
+ * Convert a kebab-case upstream directory name (e.g. "chat-shell") to the
+ * PascalCase named export it should correspond to on the Ember side (e.g.
+ * "ChatShell").
+ */
+function kebabToPascalCase(name) {
+  return name
+    .split('-')
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join('');
 }
 
 // Initialize Octokit
@@ -435,8 +453,8 @@ async function includeComponent(componentName) {
  * Compare component lists and identify changes for a single source
  */
 async function compareComponents(source, upstreamComponents, emberComponents, previousSourceData, currentCommitSHA) {
-  const missing = upstreamComponents.filter(c => !emberComponents.includes(c));
-  const implemented = upstreamComponents.filter(c => emberComponents.includes(c));
+  const missing = upstreamComponents.filter(c => !emberComponents.includes(source.nameToEmberExport(c)));
+  const implemented = upstreamComponents.filter(c => emberComponents.includes(source.nameToEmberExport(c)));
   // Meaningless for sources with no naming overlap against the Ember
   // export list yet (see `trackExtra` on the source config).
   const extra = source.trackExtra ? emberComponents.filter(c => !upstreamComponents.includes(c)) : [];
@@ -887,7 +905,8 @@ async function runSource(source, exclusions) {
  * Main execution
  */
 async function main() {
-  const sourceId = getArgValue('--source') || 'react';
+  const sourceIdArg = getArgValue('--source');
+  const sourceId = sourceIdArg || 'react';
 
   // Check for --mark-synced flag
   const markSyncedIndex = process.argv.indexOf('--mark-synced');
@@ -926,11 +945,13 @@ async function main() {
 
   console.log('Starting Carbon Components Parity Check...');
 
+  const sourcesToRun = sourceIdArg ? [getSource(sourceIdArg)] : SOURCES;
+
   const previousData = await loadParityData();
   const exclusions = await loadExclusions();
 
   const results = [];
-  for (const source of SOURCES) {
+  for (const source of sourcesToRun) {
     results.push(await runSource(source, exclusions));
   }
 

--- a/scripts/parity-check.mjs
+++ b/scripts/parity-check.mjs
@@ -2,20 +2,19 @@
 
 /**
  * Carbon Components Parity Check Script
- * 
- * This script:
- * 1. Fetches Carbon React component list from GitHub API
- * 2. Scrapes Storybook for detailed component information
+ *
+ * This script, for each configured upstream source (see SOURCES below):
+ * 1. Fetches the upstream component list from GitHub API
+ * 2. Scrapes Storybook for detailed component information (React source only)
  * 3. Compares with Ember components
  * 4. Tracks version changes
- * 5. Creates GitHub issues for differences
+ * 5. Creates GitHub issues for differences (when enabled for that source)
  */
 
 import { Octokit } from '@octokit/rest';
 import fs from 'fs/promises';
 import path from 'path';
 import { fileURLToPath } from 'url';
-import { execSync } from 'child_process';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -28,80 +27,138 @@ const PARITY_DATA_FILE = path.join(ROOT_DIR, '.parity-check-data.json');
 const EXCLUSIONS_FILE = path.join(ROOT_DIR, '.parity-check-exclusions.json');
 const GITHUB_LABEL = 'parity-check';
 
+/**
+ * Upstream sources this script tracks parity against. Each source is
+ * diffed independently: its own component list, its own commit/version
+ * tracking, its own report section and (optionally) its own GitHub issues.
+ *
+ * `id` is the key used for `.parity-check-data.json`'s `sources` object,
+ * for the `--source` CLI flag, and as a component-name namespace, so it
+ * must be stable once a source has run at least once.
+ *
+ * `createIssues` is a per-source kill switch on top of the global
+ * CREATE_ISSUES/--create-issues flag - both must allow issue creation for
+ * a given source to actually file issues. `carbon-ai-chat` starts with
+ * this off: as of this writing there isn't a single Ember component under
+ * that namespace yet, so every upstream component would show up as
+ * "missing" and a live run would immediately open ~20 issues. Flip it to
+ * `true` once the first components have landed and a normal missing/
+ * implemented split makes sense.
+ */
+const SOURCES = [
+  {
+    id: 'react',
+    label: 'Carbon React',
+    owner: 'carbon-design-system',
+    repo: 'carbon',
+    componentsPath: 'packages/react/src/components',
+    excludeDirs: [],
+    storybookStoriesUrl: 'https://react.carbondesignsystem.com/stories.json',
+    storybookBaseUrl: 'https://react.carbondesignsystem.com/',
+    issueTitlePrefix: '[Parity Check]',
+    createIssues: true,
+    // The Ember side of this addon is a 1:1 mirror of this source (it's
+    // the original, and the only one with any implemented components so
+    // far), so "components exported from Ember but not in this source"
+    // is a meaningful signal.
+    trackExtra: true,
+  },
+  {
+    id: 'carbon-ai-chat',
+    label: 'Carbon AI Chat',
+    owner: 'carbon-design-system',
+    repo: 'carbon-ai-chat',
+    // The reusable, framework-agnostic Lit widget library - the actual
+    // Ember port target. Deliberately NOT packages/ai-chat/src/chat/**,
+    // which is the React application's own internal component tree (state
+    // machine, views) rather than a reusable component surface, and NOT
+    // the web-component shell, which mounts React into shadow DOM rather
+    // than providing a framework-native implementation to port.
+    componentsPath: 'packages/ai-chat-components/src/components',
+    // Not a component - a shared-code folder alongside the real widgets.
+    excludeDirs: ['shared'],
+    storybookStoriesUrl: null,
+    storybookBaseUrl: null,
+    issueTitlePrefix: '[Parity Check][AI Chat]',
+    createIssues: false,
+    // Every existing Ember component in this addon mirrors `react`, not
+    // this source, so diffing the full Ember export list against this
+    // source's component list would report ~all of them as "extra" -
+    // meaningless noise, not a real signal. Skip it until this source has
+    // its own implemented components to actually compare against.
+    trackExtra: false,
+  },
+];
+
+function getSource(id) {
+  const source = SOURCES.find((s) => s.id === id);
+  if (!source) {
+    throw new Error(`Unknown parity source "${id}". Known sources: ${SOURCES.map((s) => s.id).join(', ')}`);
+  }
+  return source;
+}
+
 // Initialize Octokit
 const octokit = new Octokit({
   auth: process.env.GITHUB_TOKEN || process.env.GH_TOKEN
 });
 
 /**
- * Fetch the latest Carbon React version
+ * Fetch the latest release version for a source's upstream repo
  */
-async function fetchLatestCarbonVersion() {
+async function fetchLatestVersion(source) {
   try {
     const { data } = await octokit.repos.getLatestRelease({
-      owner: 'carbon-design-system',
-      repo: 'carbon'
+      owner: source.owner,
+      repo: source.repo
     });
     return data.tag_name.replace(/^v/, '');
   } catch (error) {
-    console.error('Error fetching latest Carbon version:', error.message);
-    // Fallback to package.json check
-    try {
-      const { data } = await octokit.repos.getContent({
-        owner: 'carbon-design-system',
-        repo: 'carbon',
-        path: 'packages/react/package.json'
-      });
-      const content = Buffer.from(data.content, 'base64').toString();
-      const pkg = JSON.parse(content);
-      return pkg.version;
-    } catch (fallbackError) {
-      console.error('Fallback version fetch failed:', fallbackError.message);
-      return 'unknown';
-    }
+    console.error(`Error fetching latest ${source.label} version:`, error.message);
+    return 'unknown';
   }
 }
 
 /**
  * Fetch the commit SHA for the latest release tag
  */
-async function fetchLatestReleaseCommitSHA() {
+async function fetchLatestReleaseCommitSHA(source) {
   try {
     // Get latest release
     const { data: release } = await octokit.repos.getLatestRelease({
-      owner: 'carbon-design-system',
-      repo: 'carbon'
+      owner: source.owner,
+      repo: source.repo
     });
-    
+
     // Get the tag reference
     const { data: tag } = await octokit.git.getRef({
-      owner: 'carbon-design-system',
-      repo: 'carbon',
+      owner: source.owner,
+      repo: source.repo,
       ref: `tags/${release.tag_name}`
     });
-    
+
     // The tag object contains the commit SHA
     // If it's an annotated tag, tag.object.sha points to the tag object, not commit
     // We need to get the commit that the tag points to
     let commitSha = tag.object.sha;
-    
+
     // If it's an annotated tag, we need to dereference it
     if (tag.object.type === 'tag') {
       const { data: tagObject } = await octokit.git.getTag({
-        owner: 'carbon-design-system',
-        repo: 'carbon',
+        owner: source.owner,
+        repo: source.repo,
         tag_sha: tag.object.sha
       });
       commitSha = tagObject.object.sha;
     }
-    
+
     // Get the actual commit
     const { data: commit } = await octokit.repos.getCommit({
-      owner: 'carbon-design-system',
-      repo: 'carbon',
+      owner: source.owner,
+      repo: source.repo,
       ref: commitSha
     });
-    
+
     return {
       sha: commitSha,
       date: commit.commit.committer.date,
@@ -109,7 +166,7 @@ async function fetchLatestReleaseCommitSHA() {
       tag: release.tag_name
     };
   } catch (error) {
-    console.error('Error fetching release commit:', error.message);
+    console.error(`Error fetching release commit for ${source.label}:`, error.message);
     return null;
   }
 }
@@ -117,28 +174,28 @@ async function fetchLatestReleaseCommitSHA() {
 /**
  * Fetch commits for a specific component between two SHAs
  */
-async function fetchComponentChanges(componentName, sinceSHA) {
+async function fetchComponentChanges(source, componentName, sinceSHA) {
   if (!sinceSHA) return [];
-  
+
   try {
     const { data } = await octokit.repos.listCommits({
-      owner: 'carbon-design-system',
-      repo: 'carbon',
-      path: `packages/react/src/components/${componentName}`,
+      owner: source.owner,
+      repo: source.repo,
+      path: `${source.componentsPath}/${componentName}`,
       since: new Date(Date.now() - 90 * 24 * 60 * 60 * 1000).toISOString(), // Last 90 days
       per_page: 100
     });
-    
+
     // Find commits after sinceSHA
     const sinceIndex = data.findIndex(commit => commit.sha === sinceSHA);
     if (sinceIndex === -1) {
       // SHA not found in recent history, return all
       return data;
     }
-    
+
     return data.slice(0, sinceIndex);
   } catch (error) {
-    console.error(`Error fetching changes for ${componentName}:`, error.message);
+    console.error(`Error fetching changes for ${componentName} (${source.label}):`, error.message);
     return [];
   }
 }
@@ -146,8 +203,8 @@ async function fetchComponentChanges(componentName, sinceSHA) {
 /**
  * Check if a component has been updated since last check
  */
-async function checkComponentUpdates(componentName, lastCheckedSHA) {
-  const changes = await fetchComponentChanges(componentName, lastCheckedSHA);
+async function checkComponentUpdates(source, componentName, lastCheckedSHA) {
+  const changes = await fetchComponentChanges(source, componentName, lastCheckedSHA);
   return {
     hasChanges: changes.length > 0,
     changeCount: changes.length,
@@ -157,43 +214,46 @@ async function checkComponentUpdates(componentName, lastCheckedSHA) {
 }
 
 /**
- * Fetch React component list from GitHub API
+ * Fetch a source's component list from GitHub API (directory listing)
  */
-async function fetchReactComponents() {
+async function fetchUpstreamComponents(source) {
   try {
     const { data } = await octokit.repos.getContent({
-      owner: 'carbon-design-system',
-      repo: 'carbon',
-      path: 'packages/react/src/components'
+      owner: source.owner,
+      repo: source.repo,
+      path: source.componentsPath
     });
-    
+
     return data
-      .filter(item => item.type === 'dir')
+      .filter(item => item.type === 'dir' && !source.excludeDirs?.includes(item.name))
       .map(item => item.name)
       .sort();
   } catch (error) {
-    console.error('Error fetching React components:', error.message);
+    console.error(`Error fetching ${source.label} components:`, error.message);
     return [];
   }
 }
 
 /**
- * Get Ember components from index.ts
+ * Get Ember components from index.ts. Shared across all sources: whatever
+ * gets added for a new source (e.g. an `AiChat*` component) is exported
+ * from the same public entrypoint, regardless of which subfolder it lives
+ * under, so there is no need for a per-source path here.
  */
 async function getEmberComponents() {
   try {
     const indexPath = path.join(ROOT_DIR, 'carbon-components-ember/src/components/index.ts');
     const content = await fs.readFile(indexPath, 'utf-8');
-    
+
     // Match export statements
     const exportRegex = /export\s*\{\s*default\s+as\s+(\w+)\s*\}/g;
     const components = [];
     let match;
-    
+
     while ((match = exportRegex.exec(content)) !== null) {
       components.push(match[1]);
     }
-    
+
     return components.sort();
   } catch (error) {
     console.error('Error reading Ember components:', error.message);
@@ -202,18 +262,21 @@ async function getEmberComponents() {
 }
 
 /**
- * Scrape Storybook for component details
+ * Scrape Storybook for component details (only sources that configure a
+ * storybookStoriesUrl support this - carbon-ai-chat does not have a known
+ * stories.json endpoint, so it's skipped for that source rather than
+ * guessed at).
  */
-async function scrapeStorybookComponents() {
-  // This would require a headless browser, but for now we'll use a simpler approach
-  // by fetching the stories.json file if available
+async function scrapeStorybookComponents(source) {
+  if (!source.storybookStoriesUrl) return [];
+
   try {
-    const response = await fetch('https://react.carbondesignsystem.com/stories.json');
+    const response = await fetch(source.storybookStoriesUrl);
     if (!response.ok) {
       throw new Error(`HTTP error! status: ${response.status}`);
     }
     const data = await response.json();
-    
+
     // Extract component names from stories
     const components = new Set();
     Object.keys(data.stories || {}).forEach(key => {
@@ -226,26 +289,53 @@ async function scrapeStorybookComponents() {
         }
       }
     });
-    
+
     return Array.from(components).sort();
   } catch (error) {
-    console.error('Error scraping Storybook:', error.message);
+    console.error(`Error scraping Storybook for ${source.label}:`, error.message);
     return [];
   }
 }
 
 /**
- * Load previous parity check data
+ * Load previous parity check data. Old (pre-multi-source) files only have
+ * the top-level `lastCheckedVersion`/`components`/`componentMetadata`
+ * shape, keyed implicitly to what is now the `react` source. This script
+ * keeps writing those top-level fields on every save (mirroring `react`)
+ * so nothing reading the legacy shape needs to change - but on the way
+ * *in*, an old file has no `sources.react` yet, and without migrating it
+ * here `runSource('react', ...)` would see `previousSourceData = {}`,
+ * treat every run as a first run (re-fetching "Never" as the last
+ * checked version), and both re-file "Investigate" issues for components
+ * whose issues were already closed and wipe every component's
+ * `lastSyncedCommit` back to 'N/A'. Synthesize `sources.react` from the
+ * legacy fields once, the first time this runs against an old file.
  */
 async function loadParityData() {
   try {
     const content = await fs.readFile(PARITY_DATA_FILE, 'utf-8');
-    return JSON.parse(content);
+    const data = JSON.parse(content);
+    if (!data.sources) data.sources = {};
+    if (!data.sources.react && data.lastCheckedVersion) {
+      data.sources.react = {
+        lastCheckedVersion: data.lastCheckedVersion,
+        lastCheckedCommitSHA: data.lastCheckedCommitSHA,
+        lastCheckedCommitDate: data.lastCheckedCommitDate,
+        lastCheckDate: data.lastCheckDate,
+        // Legacy shape stored the upstream component list as
+        // `components.react`; the new shape calls it `components.upstream`.
+        components: { ...data.components, upstream: data.components?.react },
+        componentMetadata: data.componentMetadata ?? {}
+      };
+    }
+    return data;
   } catch (error) {
     return {
       lastCheckedVersion: null,
       lastCheckDate: null,
-      components: {}
+      components: {},
+      componentMetadata: {},
+      sources: {}
     };
   }
 }
@@ -258,7 +348,11 @@ async function saveParityData(data) {
 }
 
 /**
- * Load component exclusions (React components intentionally not tracked for parity)
+ * Load component exclusions (upstream components intentionally not
+ * tracked for parity). Shared across all sources: upstream naming
+ * conventions don't currently overlap (PascalCase React component
+ * directories vs. kebab-case carbon-ai-chat ones), so a single flat map
+ * keyed by component name is sufficient without a source prefix.
  */
 async function loadExclusions() {
   try {
@@ -338,31 +432,33 @@ async function includeComponent(componentName) {
 }
 
 /**
- * Compare component lists and identify changes
+ * Compare component lists and identify changes for a single source
  */
-async function compareComponents(reactComponents, emberComponents, previousData, currentCommitSHA) {
-  const missing = reactComponents.filter(c => !emberComponents.includes(c));
-  const implemented = reactComponents.filter(c => emberComponents.includes(c));
-  const extra = emberComponents.filter(c => !reactComponents.includes(c));
-  
+async function compareComponents(source, upstreamComponents, emberComponents, previousSourceData, currentCommitSHA) {
+  const missing = upstreamComponents.filter(c => !emberComponents.includes(c));
+  const implemented = upstreamComponents.filter(c => emberComponents.includes(c));
+  // Meaningless for sources with no naming overlap against the Ember
+  // export list yet (see `trackExtra` on the source config).
+  const extra = source.trackExtra ? emberComponents.filter(c => !upstreamComponents.includes(c)) : [];
+
   // Identify new components since last check
   const newComponents = [];
-  if (previousData.components?.react) {
-    newComponents.push(...reactComponents.filter(c => !previousData.components.react.includes(c)));
+  if (previousSourceData.components?.upstream) {
+    newComponents.push(...upstreamComponents.filter(c => !previousSourceData.components.upstream.includes(c)));
   }
-  
-  // Check for outdated components (implemented but React version changed)
+
+  // Check for outdated components (implemented but upstream version changed)
   const outdatedComponents = [];
   const componentMetadata = {};
-  
-  if (previousData.lastCheckedCommitSHA && currentCommitSHA !== previousData.lastCheckedCommitSHA) {
-    console.log('\nChecking for component updates...');
-    
+
+  if (previousSourceData.lastCheckedCommitSHA && currentCommitSHA !== previousSourceData.lastCheckedCommitSHA) {
+    console.log(`\nChecking for component updates (${source.label})...`);
+
     for (const component of implemented) {
-      const storedLastSyncedCommit = previousData.componentMetadata?.[component]?.lastSyncedCommit;
-      const lastSyncedSHA = (storedLastSyncedCommit && storedLastSyncedCommit !== 'N/A') ? storedLastSyncedCommit : previousData.lastCheckedCommitSHA;
-      const updateInfo = await checkComponentUpdates(component, lastSyncedSHA);
-      
+      const storedLastSyncedCommit = previousSourceData.componentMetadata?.[component]?.lastSyncedCommit;
+      const lastSyncedSHA = (storedLastSyncedCommit && storedLastSyncedCommit !== 'N/A') ? storedLastSyncedCommit : previousSourceData.lastCheckedCommitSHA;
+      const updateInfo = await checkComponentUpdates(source, component, lastSyncedSHA);
+
       componentMetadata[component] = {
         lastCheckedCommit: currentCommitSHA,
         lastSyncedCommit: lastSyncedSHA,
@@ -370,7 +466,7 @@ async function compareComponents(reactComponents, emberComponents, previousData,
         changeCount: updateInfo.changeCount,
         lastUpdate: updateInfo.latestCommit?.commit?.committer?.date || null
       };
-      
+
       if (updateInfo.hasChanges) {
         outdatedComponents.push({
           name: component,
@@ -379,7 +475,7 @@ async function compareComponents(reactComponents, emberComponents, previousData,
         });
         console.log(`  ⚠️  ${component}: ${updateInfo.changeCount} changes since last sync`);
       }
-      
+
       // Rate limiting
       await new Promise(resolve => setTimeout(resolve, 100));
     }
@@ -387,18 +483,18 @@ async function compareComponents(reactComponents, emberComponents, previousData,
     // Initialize metadata for all implemented components
     for (const component of implemented) {
       // For components without prior metadata, set lastSyncedCommit to N/A
-      const hasExistingMetadata = previousData.componentMetadata?.[component] !== undefined;
+      const hasExistingMetadata = previousSourceData.componentMetadata?.[component] !== undefined;
 
       componentMetadata[component] = {
         lastCheckedCommit: currentCommitSHA,
-        lastSyncedCommit: hasExistingMetadata ? previousData.componentMetadata[component].lastSyncedCommit : 'N/A',
+        lastSyncedCommit: hasExistingMetadata ? previousSourceData.componentMetadata[component].lastSyncedCommit : 'N/A',
         hasChanges: false,
         changeCount: 0,
         lastUpdate: null
       };
     }
   }
-  
+
   return {
     missing,
     implemented,
@@ -406,7 +502,7 @@ async function compareComponents(reactComponents, emberComponents, previousData,
     newComponents,
     outdatedComponents,
     componentMetadata,
-    parity: Math.round((implemented.length / reactComponents.length) * 100)
+    parity: upstreamComponents.length > 0 ? Math.round((implemented.length / upstreamComponents.length) * 100) : 0
   };
 }
 
@@ -431,7 +527,7 @@ async function fetchOpenParityIssueTitles(owner, repo) {
 /**
  * Create GitHub issue for a missing component
  */
-async function createGitHubIssue(componentName, version, commitSHA, existingTitles) {
+async function createGitHubIssue(source, componentName, version, commitSHA, existingTitles) {
   const [owner, repo] = process.env.GITHUB_REPOSITORY?.split('/') || ['', ''];
 
   if (!owner || !repo) {
@@ -439,28 +535,33 @@ async function createGitHubIssue(componentName, version, commitSHA, existingTitl
     return null;
   }
 
-  const title = `[Parity Check] Investigate ${componentName} component`;
+  const title = `${source.issueTitlePrefix} Investigate ${componentName} component`;
+  const storybookLine = source.storybookBaseUrl
+    ? `- [ ] Check Storybook examples: ${source.storybookBaseUrl}?path=/docs/components-${componentName.toLowerCase()}--overview\n`
+    : '';
+  const storybookResource = source.storybookBaseUrl
+    ? `- [Storybook Documentation](${source.storybookBaseUrl})\n`
+    : '';
   const body = `## Component Parity Investigation
 
+**Source**: ${source.label} (${source.owner}/${source.repo})
 **Component**: ${componentName}
-**Carbon React Version**: ${version}
+**Version**: ${version}
 **Commit**: ${commitSHA?.substring(0, 7) || 'unknown'}
 **Status**: Missing in Ember implementation
 
 ### Investigation Tasks
 
-- [ ] Review React implementation: https://github.com/carbon-design-system/carbon/tree/main/packages/react/src/components/${componentName}
-- [ ] Check Storybook examples: https://react.carbondesignsystem.com/?path=/docs/components-${componentName.toLowerCase()}--overview
-- [ ] Document component API (props, events, variants)
+- [ ] Review upstream implementation: https://github.com/${source.owner}/${source.repo}/tree/main/${source.componentsPath}/${componentName}
+${storybookLine}- [ ] Document component API (props, events, variants)
 - [ ] Assess implementation complexity
 - [ ] Determine priority (High/Medium/Low)
 - [ ] Create implementation plan or decide to skip
 
 ### Resources
 
-- [Carbon React Component](https://github.com/carbon-design-system/carbon/tree/${commitSHA || 'main'}/packages/react/src/components/${componentName})
-- [Storybook Documentation](https://react.carbondesignsystem.com/)
-- [Carbon Design System](https://carbondesignsystem.com/)
+- [Upstream Component](https://github.com/${source.owner}/${source.repo}/tree/${commitSHA || 'main'}/${source.componentsPath}/${componentName})
+${storybookResource}- [${source.label}](https://github.com/${source.owner}/${source.repo})
 
 ---
 *Auto-generated by parity-check script on ${new Date().toISOString()}*
@@ -492,7 +593,7 @@ async function createGitHubIssue(componentName, version, commitSHA, existingTitl
 /**
  * Create GitHub issue for an outdated component
  */
-async function createOutdatedComponentIssue(componentInfo, version, commitSHA, existingTitles) {
+async function createOutdatedComponentIssue(source, componentInfo, version, commitSHA, existingTitles) {
   const [owner, repo] = process.env.GITHUB_REPOSITORY?.split('/') || ['', ''];
 
   if (!owner || !repo) {
@@ -500,20 +601,21 @@ async function createOutdatedComponentIssue(componentInfo, version, commitSHA, e
     return null;
   }
 
-  const title = `[Parity Check] Update ${componentInfo.name} component`;
-  
-  const commitsList = componentInfo.commits.map(commit => 
+  const title = `${source.issueTitlePrefix} Update ${componentInfo.name} component`;
+
+  const commitsList = componentInfo.commits.map(commit =>
     `- [\`${commit.sha.substring(0, 7)}\`](${commit.html_url}) ${commit.commit.message.split('\n')[0]}`
   ).join('\n');
-  
+
   const body = `## Component Update Required
 
+**Source**: ${source.label} (${source.owner}/${source.repo})
 **Component**: ${componentInfo.name}
-**Carbon React Version**: ${version}
+**Version**: ${version}
 **Latest Commit**: ${commitSHA?.substring(0, 7) || 'unknown'}
 **Changes Detected**: ${componentInfo.changeCount} commits since last sync
 
-### Recent Changes in React
+### Recent Changes Upstream
 
 ${commitsList}
 
@@ -521,7 +623,7 @@ ${componentInfo.changeCount > 5 ? `\n*...and ${componentInfo.changeCount - 5} mo
 
 ### Investigation Tasks
 
-- [ ] Review recent changes in React implementation
+- [ ] Review recent changes in upstream implementation
 - [ ] Compare with current Ember implementation
 - [ ] Identify new props, features, or bug fixes
 - [ ] Update Ember component to match
@@ -530,9 +632,9 @@ ${componentInfo.changeCount > 5 ? `\n*...and ${componentInfo.changeCount - 5} mo
 
 ### Resources
 
-- [Carbon React Component](https://github.com/carbon-design-system/carbon/tree/${commitSHA || 'main'}/packages/react/src/components/${componentInfo.name})
-- [Component Commits](https://github.com/carbon-design-system/carbon/commits/main/packages/react/src/components/${componentInfo.name})
-- [Storybook Documentation](https://react.carbondesignsystem.com/)
+- [Upstream Component](https://github.com/${source.owner}/${source.repo}/tree/${commitSHA || 'main'}/${source.componentsPath}/${componentInfo.name})
+- [Component Commits](https://github.com/${source.owner}/${source.repo}/commits/main/${source.componentsPath}/${componentInfo.name})
+- [${source.label}](https://github.com/${source.owner}/${source.repo})
 
 ---
 *Auto-generated by parity-check script on ${new Date().toISOString()}*
@@ -562,19 +664,21 @@ ${componentInfo.changeCount > 5 ? `\n*...and ${componentInfo.changeCount - 5} mo
 }
 
 /**
- * Generate parity report
+ * Generate the parity report section for a single source
  */
-async function generateReport(comparison, version, commitInfo) {
-  const report = `# Component Parity Report
+function generateReportSection(source, comparison, version, commitInfo) {
+  return `# ${source.label} Parity Report
 Generated: ${new Date().toISOString()}
-Carbon React Version: ${version}
+Upstream: ${source.owner}/${source.repo}
+Version: ${version}
 Latest Commit: ${commitInfo?.sha?.substring(0, 7) || 'unknown'} (${commitInfo?.date || 'unknown'})
 
 ## Summary
-- Total React Components: ${comparison.implemented.length + comparison.missing.length}
-- Total Ember Components: ${comparison.implemented.length + comparison.extra.length}
+- Total Upstream Components: ${comparison.implemented.length + comparison.missing.length}${source.trackExtra ? `
+- Total Ember Components (in this namespace): ${comparison.implemented.length + comparison.extra.length}` : ''}
 - Parity: ${comparison.parity}%
 - Outdated Components: ${comparison.outdatedComponents?.length || 0}
+- Issue creation for this source: ${source.createIssues ? 'enabled' : 'disabled (report-only)'}
 
 ## Missing in Ember (${comparison.missing.length})
 ${comparison.missing.map(c => `- [ ] ${c}`).join('\n')}
@@ -584,61 +688,74 @@ ${comparison.implemented.map(c => `- [x] ${c}`).join('\n')}
 
 ${comparison.outdatedComponents && comparison.outdatedComponents.length > 0 ? `
 ## Outdated Components (${comparison.outdatedComponents.length})
-These components exist in Ember but have updates in React that need to be synced:
+These components exist in Ember but have updates upstream that need to be synced:
 
 ${comparison.outdatedComponents.map(c => `- [ ] ${c.name} (${c.changeCount} changes)`).join('\n')}
 ` : ''}
 
+${source.trackExtra ? `
 ## Ember-Specific (${comparison.extra.length})
 ${comparison.extra.map(c => `- ${c}`).join('\n')}
-
+` : ''}
 ${comparison.newComponents.length > 0 ? `
 ## New Components Since Last Check (${comparison.newComponents.length})
 ${comparison.newComponents.map(c => `- ${c}`).join('\n')}
 ` : ''}
 `;
+}
 
+/**
+ * Write the combined parity report (one section per source) to disk
+ */
+async function generateReport(sections) {
+  const report = sections.join('\n---\n\n');
   const reportPath = path.join(ROOT_DIR, 'PARITY_REPORT.md');
   await fs.writeFile(reportPath, report);
   console.log(`Report generated: PARITY_REPORT.md`);
-  
   return report;
 }
 
 /**
  * Mark components as synced (update lastSyncedCommit to current release)
  */
-async function markComponentsSynced(componentNames) {
+async function markComponentsSynced(componentNames, sourceId) {
+  const source = getSource(sourceId);
   const previousData = await loadParityData();
-  const currentCommitInfo = await fetchLatestReleaseCommitSHA();
-  
+  const sourceData = previousData.sources?.[source.id] || {};
+  const currentCommitInfo = await fetchLatestReleaseCommitSHA(source);
+
   if (!currentCommitInfo) {
     console.error('Failed to fetch current release commit');
     return;
   }
-  
+
   const updated = [];
   const notFound = [];
-  
+
   for (const componentName of componentNames) {
-    if (previousData.componentMetadata?.[componentName]) {
-      previousData.componentMetadata[componentName].lastSyncedCommit = currentCommitInfo.sha;
-      previousData.componentMetadata[componentName].hasChanges = false;
-      previousData.componentMetadata[componentName].changeCount = 0;
+    if (sourceData.componentMetadata?.[componentName]) {
+      sourceData.componentMetadata[componentName].lastSyncedCommit = currentCommitInfo.sha;
+      sourceData.componentMetadata[componentName].hasChanges = false;
+      sourceData.componentMetadata[componentName].changeCount = 0;
       updated.push(componentName);
     } else {
       notFound.push(componentName);
     }
   }
-  
+
   if (updated.length > 0) {
+    previousData.sources[source.id] = sourceData;
+    if (source.id === 'react') {
+      // Legacy top-level mirror, see loadParityData()
+      previousData.componentMetadata = sourceData.componentMetadata;
+    }
     await saveParityData(previousData);
     console.log(`✅ Marked as synced (${currentCommitInfo.sha.substring(0, 7)}):`);
     updated.forEach(name => console.log(`   - ${name}`));
   }
-  
+
   if (notFound.length > 0) {
-    console.log(`\n⚠️  Not found in metadata:`);
+    console.log(`\n⚠️  Not found in metadata for source "${source.id}":`);
     notFound.forEach(name => console.log(`   - ${name}`));
   }
 }
@@ -652,14 +769,131 @@ function getArgValue(flag) {
 }
 
 /**
+ * Run the full fetch/compare/report/issue-creation pipeline for one source
+ */
+async function runSource(source, exclusions) {
+  console.log(`\n\n=== ${source.label} (${source.owner}/${source.repo}) ===\n`);
+
+  const previousData = await loadParityData();
+  const previousSourceData = previousData.sources?.[source.id] || {};
+
+  console.log(`Last checked version: ${previousSourceData.lastCheckedVersion || 'Never'}`);
+  console.log(`Last checked commit: ${previousSourceData.lastCheckedCommitSHA?.substring(0, 7) || 'Never'}`);
+
+  const currentVersion = await fetchLatestVersion(source);
+  console.log(`Current ${source.label} version: ${currentVersion}`);
+
+  const currentCommitInfo = await fetchLatestReleaseCommitSHA(source);
+  console.log(`Current release commit: ${currentCommitInfo?.sha?.substring(0, 7) || 'unknown'} (${currentCommitInfo?.tag || 'unknown'}, ${currentCommitInfo?.date || 'unknown'})\n`);
+
+  console.log(`Fetching ${source.label} components from GitHub...`);
+  const upstreamDirComponents = await fetchUpstreamComponents(source);
+  console.log(`Found ${upstreamDirComponents.length} components`);
+
+  const storybookComponents = await scrapeStorybookComponents(source);
+  if (source.storybookStoriesUrl) {
+    console.log(`Found ${storybookComponents.length} components in Storybook`);
+  }
+
+  const mergedUpstreamComponents = Array.from(new Set([...upstreamDirComponents, ...storybookComponents])).sort();
+  console.log(`Total unique ${source.label} components: ${mergedUpstreamComponents.length}`);
+
+  const excludedNames = Object.keys(exclusions);
+  const allUpstreamComponents = mergedUpstreamComponents.filter(c => !excludedNames.includes(c));
+  if (excludedNames.length > 0) {
+    console.log(`Excluding ${excludedNames.length} component(s) from tracking: ${excludedNames.join(', ')}`);
+  }
+
+  const emberComponents = await getEmberComponents();
+
+  const comparison = await compareComponents(
+    source,
+    allUpstreamComponents,
+    emberComponents,
+    { ...previousSourceData, components: { upstream: previousSourceData.components?.upstream } },
+    currentCommitInfo?.sha
+  );
+
+  console.log(`\n=== ${source.label} Comparison Results ===`);
+  console.log(`Parity: ${comparison.parity}%`);
+  console.log(`Missing: ${comparison.missing.length}`);
+  console.log(`Implemented: ${comparison.implemented.length}`);
+  console.log(`Outdated: ${comparison.outdatedComponents?.length || 0}`);
+  console.log(`Ember-specific: ${comparison.extra.length}`);
+  console.log(`New since last check: ${comparison.newComponents.length}\n`);
+
+  const commitChanged = previousSourceData.lastCheckedCommitSHA !== currentCommitInfo?.sha;
+  const versionChanged = previousSourceData.lastCheckedVersion !== currentVersion;
+  const globalCreateIssues = process.env.CREATE_ISSUES === 'true' || process.argv.includes('--create-issues');
+  const shouldCreateIssues = globalCreateIssues && source.createIssues;
+
+  if (globalCreateIssues && !source.createIssues) {
+    console.log(`Issue creation requested but disabled for source "${source.id}" (createIssues: false) - report-only.`);
+  }
+
+  if (shouldCreateIssues) {
+    console.log(`\n=== Creating GitHub Issues (${source.label}) ===`);
+
+    const [owner, repo] = process.env.GITHUB_REPOSITORY?.split('/') || ['', ''];
+    const existingTitles = (owner && repo)
+      ? await fetchOpenParityIssueTitles(owner, repo)
+      : new Set();
+
+    const componentsToInvestigate = versionChanged ? comparison.missing : comparison.newComponents;
+
+    if (componentsToInvestigate.length > 0) {
+      console.log(`Creating issues for ${componentsToInvestigate.length} missing components...`);
+      for (const component of componentsToInvestigate) {
+        await createGitHubIssue(source, component, currentVersion, currentCommitInfo?.sha, existingTitles);
+        await new Promise(resolve => setTimeout(resolve, 1000));
+      }
+    }
+
+    if (comparison.outdatedComponents && comparison.outdatedComponents.length > 0) {
+      console.log(`Creating issues for ${comparison.outdatedComponents.length} outdated components...`);
+      for (const componentInfo of comparison.outdatedComponents) {
+        await createOutdatedComponentIssue(source, componentInfo, currentVersion, currentCommitInfo?.sha, existingTitles);
+        await new Promise(resolve => setTimeout(resolve, 1000));
+      }
+    }
+  }
+
+  const newSourceData = {
+    lastCheckedVersion: currentVersion,
+    lastCheckedCommitSHA: currentCommitInfo?.sha,
+    lastCheckedCommitDate: currentCommitInfo?.date,
+    lastCheckDate: new Date().toISOString(),
+    components: {
+      upstream: allUpstreamComponents,
+      ember: emberComponents,
+      missing: comparison.missing,
+      implemented: comparison.implemented,
+      outdated: comparison.outdatedComponents?.map(c => c.name) || []
+    },
+    componentMetadata: comparison.componentMetadata || {}
+  };
+
+  return {
+    source,
+    comparison,
+    currentVersion,
+    currentCommitInfo,
+    newSourceData,
+    reportSection: generateReportSection(source, comparison, currentVersion, currentCommitInfo)
+  };
+}
+
+/**
  * Main execution
  */
 async function main() {
+  const sourceId = getArgValue('--source') || 'react';
+
   // Check for --mark-synced flag
   const markSyncedIndex = process.argv.indexOf('--mark-synced');
   if (markSyncedIndex !== -1 && process.argv[markSyncedIndex + 1]) {
     const components = process.argv[markSyncedIndex + 1].split(',').map(s => s.trim());
-    await markComponentsSynced(components);
+    await markComponentsSynced(components, sourceId);
     return;
   }
 
@@ -690,117 +924,46 @@ async function main() {
     return;
   }
 
-  console.log('Starting Carbon Components Parity Check...\n');
-  
-  // Load previous data
+  console.log('Starting Carbon Components Parity Check...');
+
   const previousData = await loadParityData();
-  console.log(`Last checked version: ${previousData.lastCheckedVersion || 'Never'}`);
-  console.log(`Last checked commit: ${previousData.lastCheckedCommitSHA?.substring(0, 7) || 'Never'}`);
-  
-  // Fetch current version and commit
-  const currentVersion = await fetchLatestCarbonVersion();
-  console.log(`Current Carbon React version: ${currentVersion}`);
-  
-  const currentCommitInfo = await fetchLatestReleaseCommitSHA();
-  console.log(`Current release commit: ${currentCommitInfo?.sha?.substring(0, 7) || 'unknown'} (${currentCommitInfo?.tag || 'unknown'}, ${currentCommitInfo?.date || 'unknown'})\n`);
-  
-  // Fetch component lists
-  console.log('Fetching React components from GitHub...');
-  const reactComponents = await fetchReactComponents();
-  console.log(`Found ${reactComponents.length} React components`);
-  
-  console.log('Fetching React components from Storybook...');
-  const storybookComponents = await scrapeStorybookComponents();
-  console.log(`Found ${storybookComponents.length} components in Storybook`);
-  
-  // Merge and deduplicate
-  const mergedReactComponents = Array.from(new Set([...reactComponents, ...storybookComponents])).sort();
-  console.log(`Total unique React components: ${mergedReactComponents.length}`);
-
-  // Drop components that were deliberately excluded from parity tracking
-  // (doesn't make sense in an Ember context, or already covered by another component)
   const exclusions = await loadExclusions();
-  const excludedNames = Object.keys(exclusions);
-  const allReactComponents = mergedReactComponents.filter(c => !excludedNames.includes(c));
-  if (excludedNames.length > 0) {
-    console.log(`Excluding ${excludedNames.length} component(s) from tracking: ${excludedNames.join(', ')}`);
+
+  const results = [];
+  for (const source of SOURCES) {
+    results.push(await runSource(source, exclusions));
   }
 
-  console.log('Reading Ember components...');
-  const emberComponents = await getEmberComponents();
-  console.log(`Found ${emberComponents.length} Ember components\n`);
-  
-  // Compare (now async to check for updates)
-  const comparison = await compareComponents(
-    allReactComponents, 
-    emberComponents, 
-    previousData,
-    currentCommitInfo?.sha
-  );
-  
-  console.log('\n=== Comparison Results ===');
-  console.log(`Parity: ${comparison.parity}%`);
-  console.log(`Missing: ${comparison.missing.length}`);
-  console.log(`Implemented: ${comparison.implemented.length}`);
-  console.log(`Outdated: ${comparison.outdatedComponents?.length || 0}`);
-  console.log(`Ember-specific: ${comparison.extra.length}`);
-  console.log(`New since last check: ${comparison.newComponents.length}\n`);
-  
-  // Generate report
-  await generateReport(comparison, currentVersion, currentCommitInfo);
-  
-  // Create issues for new/missing/outdated components
-  const commitChanged = previousData.lastCheckedCommitSHA !== currentCommitInfo?.sha;
-  const versionChanged = previousData.lastCheckedVersion !== currentVersion;
-  const shouldCreateIssues = process.env.CREATE_ISSUES === 'true' || process.argv.includes('--create-issues');
-  
-  if (shouldCreateIssues) {
-    console.log('\n=== Creating GitHub Issues ===');
+  await generateReport(results.map(r => r.reportSection));
 
-    const [owner, repo] = process.env.GITHUB_REPOSITORY?.split('/') || ['', ''];
-    const existingTitles = (owner && repo)
-      ? await fetchOpenParityIssueTitles(owner, repo)
-      : new Set();
-
-    // Create issues for missing components (new or all if version changed)
-    const componentsToInvestigate = versionChanged ? comparison.missing : comparison.newComponents;
-
-    if (componentsToInvestigate.length > 0) {
-      console.log(`Creating issues for ${componentsToInvestigate.length} missing components...`);
-      for (const component of componentsToInvestigate) {
-        await createGitHubIssue(component, currentVersion, currentCommitInfo?.sha, existingTitles);
-        // Rate limiting
-        await new Promise(resolve => setTimeout(resolve, 1000));
-      }
-    }
-
-    // Create issues for outdated components
-    if (comparison.outdatedComponents && comparison.outdatedComponents.length > 0) {
-      console.log(`Creating issues for ${comparison.outdatedComponents.length} outdated components...`);
-      for (const componentInfo of comparison.outdatedComponents) {
-        await createOutdatedComponentIssue(componentInfo, currentVersion, currentCommitInfo?.sha, existingTitles);
-        // Rate limiting
-        await new Promise(resolve => setTimeout(resolve, 1000));
-      }
-    }
+  const sources = { ...previousData.sources };
+  for (const result of results) {
+    sources[result.source.id] = result.newSourceData;
   }
-  
-  // Save current state with enhanced metadata
+
+  const reactResult = results.find(r => r.source.id === 'react');
+
   const newData = {
-    lastCheckedVersion: currentVersion,
-    lastCheckedCommitSHA: currentCommitInfo?.sha,
-    lastCheckedCommitDate: currentCommitInfo?.date,
+    // Legacy top-level shape, mirroring the `react` source, kept for
+    // backward compatibility with anything still reading the pre-multi-
+    // source file layout (see loadParityData()).
+    lastCheckedVersion: reactResult?.newSourceData.lastCheckedVersion ?? previousData.lastCheckedVersion,
+    lastCheckedCommitSHA: reactResult?.newSourceData.lastCheckedCommitSHA ?? previousData.lastCheckedCommitSHA,
+    lastCheckedCommitDate: reactResult?.newSourceData.lastCheckedCommitDate ?? previousData.lastCheckedCommitDate,
     lastCheckDate: new Date().toISOString(),
-    components: {
-      react: allReactComponents,
-      ember: emberComponents,
-      missing: comparison.missing,
-      implemented: comparison.implemented,
-      outdated: comparison.outdatedComponents?.map(c => c.name) || []
-    },
-    componentMetadata: comparison.componentMetadata || {}
+    components: reactResult
+      ? {
+          react: reactResult.newSourceData.components.upstream,
+          ember: reactResult.newSourceData.components.ember,
+          missing: reactResult.newSourceData.components.missing,
+          implemented: reactResult.newSourceData.components.implemented,
+          outdated: reactResult.newSourceData.components.outdated
+        }
+      : previousData.components,
+    componentMetadata: reactResult?.newSourceData.componentMetadata ?? previousData.componentMetadata,
+    sources
   };
-  
+
   await saveParityData(newData);
   console.log('\nParity check data saved.');
   console.log('Done!');


### PR DESCRIPTION
## Summary
- Generalizes `scripts/parity-check.mjs` from a single hardcoded Carbon React source into a `SOURCES`-driven pipeline, and adds `carbon-design-system/carbon-ai-chat` (`packages/ai-chat-components/src/components`, the reusable Lit widget library that is the actual Ember port target - not the React app internals or the web-component/shadow-DOM shell) as a second tracked source.
- Issue creation is disabled for the new source (`createIssues: false`) until an Ember component exists under that namespace - otherwise every upstream component would be reported "missing" on the first run and flood the issue tracker.
- `.parity-check-data.json` gains a per-source `sources` object; the legacy top-level fields stay in sync with the `react` source for backward compatibility with the weekly workflow and `fix-parity-issue.sh`. An old-shape file is migrated into `sources.react` on load, so a stale file isn't misread as "never checked" (which would otherwise re-file closed issues and wipe every component's recorded sync commit).
- The non-component `shared` directory under carbon-ai-chat's components path is excluded, and the "Ember-specific" report section/count is only computed for sources with `trackExtra: true` (react), since it would otherwise be 100% false positives for a source with no implemented Ember components yet.

## Test plan
- [x] `node -c scripts/parity-check.mjs` (syntax)
- [x] Full run (`node parity-check.mjs`, `CREATE_ISSUES` unset) against a scratch copy of the real `.parity-check-data.json` - both sources fetch/compare/report correctly, `PARITY_REPORT.md` has one section per source
- [x] Re-ran against a **pristine** copy of the real data file to confirm the old-shape migration works on first read: `Last checked version` correctly reads `11.112.0` (not `Never`), and `componentMetadata.*.lastSyncedCommit` values are preserved (not reset to `N/A`)
- [x] `--mark-synced Button` succeeds against a pristine copy with no prior full run
- [x] `--exclude`/`--include`/`--list-exclusions` round-trip unchanged
- [x] Confirmed `shared` is excluded from the carbon-ai-chat component list and the real repo's tracked `.parity-check-data.json`/`.parity-check-exclusions.json` files were never touched during testing (only scratch copies under `/tmp`)