### PR TITLE
fix: retry gh-pages push on race in deploy workflow

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -131,14 +131,28 @@ jobs:
           ref: gh-pages
           path: gh-pages
       - run: |-
-          cp -r ./docs-app/gh-pages/versions/* $GITHUB_WORKSPACE/gh-pages/versions/
           cd $GITHUB_WORKSPACE/gh-pages
-
           git config --global user.name 'Patrick Pircher'
           git config --global user.email 'patricklx@users.noreply.github.com'
-          git add .
-          git commit -m 'docs'
-          git push
+          for i in 1 2 3 4 5; do
+            cp -r $GITHUB_WORKSPACE/docs-app/gh-pages/versions/* versions/
+            git add .
+            if git diff --staged --quiet; then
+              echo "No changes to deploy"
+              exit 0
+            fi
+            git commit -m 'docs'
+            if git push; then
+              exit 0
+            fi
+            echo "Push rejected (attempt $i), retrying against latest gh-pages..."
+            git reset --hard HEAD~1
+            git fetch origin gh-pages
+            git reset --hard origin/gh-pages
+            sleep $((RANDOM % 5 + 1))
+          done
+          echo "Failed to push to gh-pages after retries"
+          exit 1
 
 
 


### PR DESCRIPTION
## Summary
- Main's `deploy` job (`nodejs.yml`) failed on its latest run with `! [rejected] gh-pages -> gh-pages (fetch first)` — a bare `git push` to `gh-pages` lost a race against a concurrent push (e.g. a PR docs preview) and errored instead of retrying, so main's docs didn't get published.
- `pr-preview.yml` already handles this exact race with a fetch/reset/retry loop; this PR gives the main `deploy` step the same pattern (up to 5 attempts, re-copying the built docs and re-committing against the freshly fetched `gh-pages` tip each time).

## Test plan
- [x] YAML parses (`python3 -c "import yaml; yaml.safe_load(...)"`)
- [x] Diff is scoped to only `.github/workflows/nodejs.yml`
- [ ] Can't run this workflow locally — the retry path only exercises when a real concurrent push happens; the happy path (`git push` succeeds first try) is unchanged from before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)