### PR TITLE
refactor: type constructor owner as Owner instead of any

### DIFF
--- a/carbon-components-ember/src/components/fluid-text-input.gts
+++ b/carbon-components-ember/src/components/fluid-text-input.gts
@@ -1,4 +1,5 @@
 import Component from '@glimmer/component';
+import type Owner from '@ember/owner';
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
 import { guidFor } from '@ember/object/internals';
@@ -40,7 +41,7 @@ export default class FluidTextInput extends Component<Signature> {
 
   guid = guidFor(this);
 
-  constructor(owner: any, args: Signature['Args']) {
+  constructor(owner: Owner, args: Signature['Args']) {
     super(owner, args);
     this.internalValue = args.defaultValue ?? '';
   }

--- a/carbon-components-ember/src/components/number-input.gts
+++ b/carbon-components-ember/src/components/number-input.gts
@@ -6,6 +6,7 @@
  */
 
 import Component from '@glimmer/component';
+import type Owner from '@ember/owner';
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
 import { guidFor } from '@ember/object/internals';
@@ -61,7 +62,7 @@ export default class NumberInput extends Component<Signature> {
 
   guid = guidFor(this);
 
-  constructor(owner: any, args: Signature['Args']) {
+  constructor(owner: Owner, args: Signature['Args']) {
     super(owner, args);
     this.internalValue = args.defaultValue ?? 0;
   }

--- a/carbon-components-ember/src/components/password-input.gts
+++ b/carbon-components-ember/src/components/password-input.gts
@@ -6,6 +6,7 @@
  */
 
 import Component from '@glimmer/component';
+import type Owner from '@ember/owner';
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
 import { guidFor } from '@ember/object/internals';
@@ -51,7 +52,7 @@ export default class PasswordInput extends Component<Signature> {
 
   guid = guidFor(this);
 
-  constructor(owner: any, args: Signature['Args']) {
+  constructor(owner: Owner, args: Signature['Args']) {
     super(owner, args);
     this.internalValue = args.defaultValue ?? '';
     this.passwordVisible = (args.type ?? 'password') === 'text';

--- a/carbon-components-ember/src/components/popover.gts
+++ b/carbon-components-ember/src/components/popover.gts
@@ -6,6 +6,7 @@
  */
 
 import Component from '@glimmer/component';
+import type Owner from '@ember/owner';
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
 import { registerDestructor } from '@ember/destroyable';
@@ -162,7 +163,7 @@ export default class Popover extends Component<PopoverSignature> {
 
   containerElement?: HTMLElement;
 
-  constructor(owner: any, args: PopoverArgs) {
+  constructor(owner: Owner, args: PopoverArgs) {
     super(owner, args);
     registerDestructor(this, () => {
       document.removeEventListener('click', this.handleDocumentClick);

--- a/carbon-components-ember/src/components/progress-indicator.gts
+++ b/carbon-components-ember/src/components/progress-indicator.gts
@@ -6,6 +6,7 @@
  */
 
 import Component from '@glimmer/component';
+import type Owner from '@ember/owner';
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
 import { on } from '@ember/modifier';
@@ -70,7 +71,7 @@ class ProgressStep extends Component<{
   Args: ProgressStepArgs & { indicator: ProgressIndicator };
   Element: HTMLLIElement;
 }> {
-  constructor(owner: any, args: ProgressStep['args']) {
+  constructor(owner: Owner, args: ProgressStep['args']) {
     super(owner, args);
     runTask(this, () => {
       if (this.isDestroyed) {

--- a/carbon-components-ember/src/components/slider.gts
+++ b/carbon-components-ember/src/components/slider.gts
@@ -1,4 +1,5 @@
 import Component from '@glimmer/component';
+import type Owner from '@ember/owner';
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
 import { guidFor } from '@ember/object/internals';
@@ -56,7 +57,7 @@ export default class Slider extends Component<SliderSignature> {
   lowerThumbElement?: HTMLDivElement;
   upperThumbElement?: HTMLDivElement;
 
-  constructor(owner: any, args: Args) {
+  constructor(owner: Owner, args: Args) {
     super(owner, args);
     registerDestructor(this, () => this.removeDragListeners());
   }

--- a/carbon-components-ember/src/components/text-area.gts
+++ b/carbon-components-ember/src/components/text-area.gts
@@ -1,4 +1,5 @@
 import Component from '@glimmer/component';
+import type Owner from '@ember/owner';
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
 import { guidFor } from '@ember/object/internals';
@@ -50,7 +51,7 @@ export default class TextArea extends Component<Signature> {
 
   guid = guidFor(this);
 
-  constructor(owner: any, args: Signature['Args']) {
+  constructor(owner: Owner, args: Signature['Args']) {
     super(owner, args);
     this.internalValue = args.defaultValue ?? '';
   }

--- a/carbon-components-ember/src/components/text-input.gts
+++ b/carbon-components-ember/src/components/text-input.gts
@@ -1,4 +1,5 @@
 import Component from '@glimmer/component';
+import type Owner from '@ember/owner';
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
 import { guidFor } from '@ember/object/internals';
@@ -37,7 +38,7 @@ export default class TextInput extends Component<Signature> {
 
   guid = guidFor(this);
 
-  constructor(owner: any, args: Signature['Args']) {
+  constructor(owner: Owner, args: Signature['Args']) {
     super(owner, args);
     this.internalValue = args.defaultValue ?? '';
   }

--- a/carbon-components-ember/src/components/time-picker.gts
+++ b/carbon-components-ember/src/components/time-picker.gts
@@ -6,6 +6,7 @@
  */
 
 import Component from '@glimmer/component';
+import type Owner from '@ember/owner';
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
 import { guidFor } from '@ember/object/internals';
@@ -129,7 +130,7 @@ export default class TimePicker extends Component<Signature> {
 
   guid = guidFor(this);
 
-  constructor(owner: any, args: Signature['Args']) {
+  constructor(owner: Owner, args: Signature['Args']) {
     super(owner, args);
     this.internalValue = args.defaultValue ?? '';
   }

--- a/carbon-components-ember/src/components/time-picker/time-picker-select.gts
+++ b/carbon-components-ember/src/components/time-picker/time-picker-select.gts
@@ -6,6 +6,7 @@
  */
 
 import Component from '@glimmer/component';
+import type Owner from '@ember/owner';
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
 import { guidFor } from '@ember/object/internals';
@@ -55,7 +56,7 @@ export default class TimePickerSelect extends Component<Signature> {
 
   guid = guidFor(this);
 
-  constructor(owner: any, args: Signature['Args']) {
+  constructor(owner: Owner, args: Signature['Args']) {
     super(owner, args);
     this.internalValue = args.defaultValue ?? '';
   }

--- a/carbon-components-ember/src/components/tooltip.gts
+++ b/carbon-components-ember/src/components/tooltip.gts
@@ -6,6 +6,7 @@
  */
 
 import Component from '@glimmer/component';
+import type Owner from '@ember/owner';
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
 import { guidFor } from '@ember/object/internals';
@@ -124,7 +125,7 @@ export default class CarbonTooltip extends Component<CarbonTooltipSignature> {
   timer?: ReturnType<typeof setTimeout>;
   containerElement?: HTMLElement;
 
-  constructor(owner: any, args: Args) {
+  constructor(owner: Owner, args: Args) {
     super(owner, args);
     registerDestructor(this, () => clearTimeout(this.timer));
   }

--- a/carbon-components-ember/src/components/ui-shell/-header-container.gts
+++ b/carbon-components-ember/src/components/ui-shell/-header-container.gts
@@ -1,4 +1,5 @@
 import Component from '@glimmer/component';
+import type Owner from '@ember/owner';
 import { tracked } from '@glimmer/tracking';
 import { registerDestructor } from '@ember/destroyable';
 import { hash } from '@ember/helper';
@@ -20,7 +21,7 @@ export interface UIShellHeaderContainerSignature {
 export default class UIShellHeaderContainer extends Component<UIShellHeaderContainerSignature> {
   @tracked isSideNavExpanded = this.args.isSideNavExpanded ?? false;
 
-  constructor(owner: any, args: UIShellHeaderContainerSignature['Args']) {
+  constructor(owner: Owner, args: UIShellHeaderContainerSignature['Args']) {
     super(owner, args);
     window.addEventListener('keydown', this.handleWindowKeydown);
     registerDestructor(this, () => {


### PR DESCRIPTION
## Summary
- Found by the 2026-09-09 Ember best-practices audit (AGENTS.md): 12 components still typed their `constructor`'s `owner` param as `any` instead of the real `Owner` type.
- Switched each to `import type Owner from '@ember/owner'` / `constructor(owner: Owner, args: Signature['Args'])`, matching the convention already used elsewhere in the addon (`tabs.gts`, `date-picker.gts`, `dropdown.gts`, …).
- Files: `time-picker.gts`, `text-area.gts`, `slider.gts`, `popover.gts`, `fluid-text-input.gts`, `progress-indicator.gts`, `tooltip.gts`, `number-input.gts`, `password-input.gts`, `text-input.gts`, `time-picker/time-picker-select.gts`, `ui-shell/-header-container.gts`.
- Type-only change, no behavior difference.

## Test plan
- [x] `pnpm build:types` (glint) — clean
- [x] `pnpm build:js` (rollup) — clean
- [x] `pnpm lint` (hbs/types/js) — 0 errors (pre-existing unrelated warnings only)
- [x] Full `test-app` suite: 657/657 green

🤖 Generated with [Claude Code](https://claude.com/claude-code)