### PR TITLE
refactor: migrate Slider off @ember/render-modifiers, de-duplicate handle markup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -509,13 +509,13 @@ for the reader of the docs site, not for yourself.
   It observes render rather than state, doesn't compose, and has no teardown
   story. Write a real modifier instead (§4). As of the 2026-09-09 audit,
   13 components still imported it; `checkbox.gts`, `code-snippet.gts`,
-  `list.gts`, `ordered-list.gts`, `search.gts`, and `toggletip.gts` have
-  since been migrated off it. 7 components still import it:
-  `charts/-components/chart.gts`, `data-table.gts`, `pagination.gts`,
-  `popover.gts`, `select.gts`, `slider.gts`, `tooltip.gts`. Migrating one of
-  these to a real modifier while you're already touching it for something
-  else is in-scope cleanup, not scope creep — don't do a drive-by rewrite of
-  an unrelated file just to cross it off this list.
+  `list.gts`, `ordered-list.gts`, `search.gts`, `toggletip.gts`, and
+  `slider.gts` have since been migrated off it. 6 components still import
+  it: `charts/-components/chart.gts`, `data-table.gts`, `pagination.gts`,
+  `popover.gts`, `select.gts`, `tooltip.gts`. Migrating one of these to a
+  real modifier while you're already touching it for something else is
+  in-scope cleanup, not scope creep — don't do a drive-by rewrite of an
+  unrelated file just to cross it off this list.
 - **An ad-hoc `willDestroy()` lifecycle override** instead of
   `registerDestructor` or a modifier's own teardown function (see §6).
   `ordered-list.gts`'s has since been replaced with a modifier teardown; one
@@ -704,17 +704,13 @@ re-derive them from scratch.
   codebase; a hand-written component reaching for `import()` instead of a
   static import is not following an established pattern here and should be
   questioned.
-- **`slider.gts`'s `<template>` block (~228 lines) duplicates its
-  lower/upper-handle markup wholesale** — the two handle SVG pairs
-  (`cds--slider__thumb-icon--lower` / `--upper`) and the two text-input
-  wrapper blocks are near-identical, differing only in a `--lower`/`--upper`
-  class suffix and which arg (`@value`/`@valueUpper`, `@ariaLabelInput`/
-  `@ariaLabelInputUpper`) each reads. This is the addon's clearest instance
-  of "huge template + duplication" together, and it has an idiomatic fix
-  already established elsewhere in this codebase: extract a private
-  sub-component parameterized by handle position (the same shape as
-  `tree-view/-node.gts` or `data-table/-header.gts`), invoked twice instead
-  of the markup being written out twice.
+- **`slider.gts`'s `<template>` block duplicated its lower/upper-handle
+  markup wholesale — fixed (2026-09-09).** The two handle SVG pairs and the
+  two text-input wrapper blocks differed only in a `--lower`/`--upper` class
+  suffix and which arg each read, so they're now two private sub-components,
+  `slider/-thumb.gts` and `slider/-text-input.gts`, each invoked twice from
+  `slider.gts` with the differing bits already resolved into plain args —
+  the same shape as `tree-view/-node.gts` or `data-table/-header.gts`.
 - **Not a problem, checked directly rather than assumed:** the number of
   overly-long *methods* (as opposed to templates) is small. Several
   candidates that looked suspicious from a rough line-count scan turned out,
@@ -741,7 +737,10 @@ migration (`checkbox.gts`, `code-snippet.gts`, `list.gts`,
 `ordered-list.gts`, `search.gts`, `toggletip.gts`, plus `ordered-list.gts`'s
 `willDestroy`) was also done as its own follow-up (2026-09-09) — see the
 "What NOT to Reach For" entries above, now updated to reflect the remaining
-7-component/1-component counts.
+counts. `slider.gts` was migrated off `@ember/render-modifiers` and had its
+template de-duplicated in the same follow-up PR, since both changes touched
+the same file — see the "What NOT to Reach For" entries above and the debt
+bullet above, now updated to reflect both.
 
 ## Key Resources
 

--- a/carbon-components-ember/package.json
+++ b/carbon-components-ember/package.json
@@ -2963,6 +2963,8 @@
       "./components/carbon/skeleton-text.js": "./dist/_app_/components/carbon/skeleton-text.js",
       "./components/carbon/slider-skeleton.js": "./dist/_app_/components/carbon/slider-skeleton.js",
       "./components/carbon/slider.js": "./dist/_app_/components/carbon/slider.js",
+      "./components/carbon/slider/-text-input.js": "./dist/_app_/components/carbon/slider/-text-input.js",
+      "./components/carbon/slider/-thumb.js": "./dist/_app_/components/carbon/slider/-thumb.js",
       "./components/carbon/stack.js": "./dist/_app_/components/carbon/stack.js",
       "./components/carbon/structured-list.js": "./dist/_app_/components/carbon/structured-list.js",
       "./components/carbon/structured-list/-body.js": "./dist/_app_/components/carbon/structured-list/-body.js",

--- a/carbon-components-ember/src/components/slider.gts
+++ b/carbon-components-ember/src/components/slider.gts
@@ -5,13 +5,20 @@ import { action } from '@ember/object';
 import { guidFor } from '@ember/object/internals';
 import { registerDestructor } from '@ember/destroyable';
 import { on } from '@ember/modifier';
-import { fn, concat } from '@ember/helper';
+import { concat } from '@ember/helper';
 import { htmlSafe } from '@ember/template';
-import didInsert from '@ember/render-modifiers/modifiers/did-insert';
-import { and, not, or } from 'ember-truth-helpers';
-import { WarningFilled, WarningAltFilled } from '../icons.ts';
+import { modifier } from 'ember-modifier';
+import SliderThumb from './slider/-thumb.gts';
+import SliderTextInput from './slider/-text-input.gts';
 
 export type HandlePosition = 'lower' | 'upper';
+
+const registerElement = modifier<{
+  Element: HTMLDivElement;
+  Args: { Positional: [(element: HTMLDivElement) => void] };
+}>((element, [onInsert]) => {
+  onInsert(element);
+});
 
 export type Args = {
   ariaLabelInput?: string;
@@ -149,6 +156,11 @@ export default class Slider extends Component<SliderSignature> {
       return this.editingUpper ?? String(this.args.valueUpper ?? '');
     }
     return this.editingUpper ?? String(this.args.value ?? '');
+  }
+
+  get upperInputAriaLabelledby() {
+    if (this.args.ariaLabelInput || this.twoHandles) return undefined;
+    return `${this.id}-label`;
   }
 
   discreteValueForPercent(percent: number) {
@@ -412,42 +424,26 @@ export default class Slider extends Component<SliderSignature> {
           {{if @readOnly "cds--slider-container--readonly"}}'
       >
         {{#if this.twoHandles}}
-          <div
-            class='cds--text-input-wrapper cds--slider-text-input-wrapper
-              cds--slider-text-input-wrapper--lower
-              {{if @readOnly "cds--text-input-wrapper--readonly"}}
-              {{if @hideTextInput "cds--slider-text-input-wrapper--hidden"}}'
-          >
-            {{! template-lint-disable require-input-label }}
-            <input
-              type={{if @hideTextInput "hidden" "number"}}
-              id='{{this.id}}-lower-input-for-slider'
-              name={{@name}}
-              class='cds--text-input cds--slider-text-input cds--slider-text-input--lower
-                {{if @invalid "cds--text-input--invalid"}}'
-              value={{this.lowerDisplayValue}}
-              aria-label={{@ariaLabelInput}}
-              disabled={{@disabled}}
-              required={{@required}}
-              min={{@min}}
-              max={{@max}}
-              step={{@step}}
-              readonly={{@readOnly}}
-              aria-invalid={{if @invalid "true"}}
-              {{on 'change' (fn this.onInputChange 'lower')}}
-              {{on 'input' (fn this.onInputChange 'lower')}}
-              {{on 'blur' (fn this.onInputBlur 'lower')}}
-              {{on 'keydown' (fn this.onInputKeyDown 'lower')}}
-            />
-            {{#if @invalid}}
-              <WarningFilled @size='16' @svgClass='cds--slider__invalid-icon' />
-            {{else if @warn}}
-              <WarningAltFilled
-                @size='16'
-                @svgClass='cds--slider__invalid-icon cds--slider__invalid-icon--warning'
-              />
-            {{/if}}
-          </div>
+          <SliderTextInput
+            @handle='lower'
+            @suffix='lower'
+            @id='{{this.id}}-lower-input-for-slider'
+            @name={{@name}}
+            @value={{this.lowerDisplayValue}}
+            @ariaLabel={{@ariaLabelInput}}
+            @disabled={{@disabled}}
+            @required={{@required}}
+            @min={{@min}}
+            @max={{@max}}
+            @step={{@step}}
+            @readOnly={{@readOnly}}
+            @invalid={{@invalid}}
+            @warn={{@warn}}
+            @hideTextInput={{@hideTextInput}}
+            @onChange={{this.onInputChange}}
+            @onBlur={{this.onInputBlur}}
+            @onKeyDown={{this.onInputKeyDown}}
+          />
         {{/if}}
 
         <span class='cds--slider__range-label'>{{this.formatLabel @min @minLabel}}</span>
@@ -457,98 +453,43 @@ export default class Slider extends Component<SliderSignature> {
           role='presentation'
           tabindex='-1'
           data-invalid={{if @invalid "true"}}
-          {{didInsert this.registerTrack}}
+          {{registerElement this.registerTrack}}
           {{! template-lint-disable no-pointer-down-event-binding }}
           {{on 'mousedown' this.onDragStart}}
           {{on 'touchstart' this.onDragStart}}
           {{on 'keydown' this.onKeyDown}}
         >
-          <div
-            class='cds--icon-tooltip cds--slider__thumb-wrapper
-              {{if this.twoHandles "cds--slider__thumb-wrapper--lower"}}'
-            style={{this.lowerThumbStyle}}
-          >
-            {{! template-lint-disable require-presentational-children }}
-            <div
-              class='cds--slider__thumb {{if this.twoHandles "cds--slider__thumb--lower"}}'
-              role='slider'
-              id={{unless this.twoHandles this.id}}
-              tabindex={{if (or @readOnly @disabled) undefined 0}}
-              aria-valuetext={{this.formatLabel @value}}
-              aria-valuemax={{if this.twoHandles @valueUpper @max}}
-              aria-valuemin={{@min}}
-              aria-valuenow={{@value}}
-              aria-labelledby={{unless this.twoHandles (concat this.id "-label")}}
-              aria-label={{if this.twoHandles @ariaLabelInput}}
-              {{didInsert this.registerLowerThumb}}
-              {{on 'focus' this.onLowerFocus}}
-            >
-              {{#if this.twoHandles}}
-                <svg
-                  xmlns='http://www.w3.org/2000/svg'
-                  viewBox='0 0 16 24'
-                  class='cds--slider__thumb-icon cds--slider__thumb-icon--lower'
-                >
-                  <path
-                    d='M15.08 6.46H16v11.08h-.92zM4.46 17.54c-.25 0-.46-.21-.46-.46V6.92a.465.465 0 0 1 .69-.4l8.77 5.08a.46.46 0 0 1 0 .8l-8.77 5.08c-.07.04-.15.06-.23.06Z'
-                  />
-                </svg>
-                <svg
-                  xmlns='http://www.w3.org/2000/svg'
-                  viewBox='0 0 16 24'
-                  class='cds--slider__thumb-icon cds--slider__thumb-icon--lower cds--slider__thumb-icon--focus'
-                >
-                  <path
-                    d='M15.08 6.46H16v11.08h-.92zM4.46 17.54c-.25 0-.46-.21-.46-.46V6.92a.465.465 0 0 1 .69-.4l8.77 5.08a.46.46 0 0 1 0 .8l-8.77 5.08c-.07.04-.15.06-.23.06Z'
-                  />
-                  <path d='M15.08 0H16v6.46h-.92z' />
-                  <path d='M0 0h.92v24H0zM15.08 0H16v24h-.92z' />
-                  <path d='M0 .92V0h16v.92zM0 24v-.92h16V24z' />
-                </svg>
-              {{/if}}
-            </div>
-          </div>
+          <SliderThumb
+            @position='lower'
+            @twoHandles={{this.twoHandles}}
+            @style={{this.lowerThumbStyle}}
+            @id={{unless this.twoHandles this.id}}
+            @disabled={{@disabled}}
+            @readOnly={{@readOnly}}
+            @ariaValueText={{this.formatLabel @value}}
+            @ariaValueMax={{if this.twoHandles @valueUpper @max}}
+            @ariaValueMin={{@min}}
+            @ariaValueNow={{@value}}
+            @ariaLabelledby={{unless this.twoHandles (concat this.id "-label")}}
+            @ariaLabel={{if this.twoHandles @ariaLabelInput}}
+            @onFocus={{this.onLowerFocus}}
+            @registerElement={{this.registerLowerThumb}}
+          />
 
           {{#if this.twoHandles}}
-            <div
-              class='cds--icon-tooltip cds--slider__thumb-wrapper cds--slider__thumb-wrapper--upper'
-              style={{this.upperThumbStyle}}
-            >
-              {{! template-lint-disable require-presentational-children }}
-              <div
-                class='cds--slider__thumb cds--slider__thumb--upper'
-                role='slider'
-                tabindex={{if (or @readOnly @disabled) undefined 0}}
-                aria-valuemax={{@max}}
-                aria-valuemin={{@value}}
-                aria-valuenow={{@valueUpper}}
-                aria-label={{@ariaLabelInputUpper}}
-                {{didInsert this.registerUpperThumb}}
-                {{on 'focus' this.onUpperFocus}}
-              >
-                <svg
-                  xmlns='http://www.w3.org/2000/svg'
-                  viewBox='0 0 16 24'
-                  class='cds--slider__thumb-icon cds--slider__thumb-icon--upper'
-                >
-                  <path
-                    d='M0 6.46h.92v11.08H0zM11.54 6.46c.25 0 .46.21.46.46v10.15a.465.465 0 0 1-.69.4L2.54 12.4a.46.46 0 0 1 0-.8l8.77-5.08c.07-.04.15-.06.23-.06Z'
-                  />
-                </svg>
-                <svg
-                  xmlns='http://www.w3.org/2000/svg'
-                  viewBox='0 0 16 24'
-                  class='cds--slider__thumb-icon cds--slider__thumb-icon--upper cds--slider__thumb-icon--focus'
-                >
-                  <path
-                    d='M0 6.46h.92v11.08H0zM11.54 6.46c.25 0 .46.21.46.46v10.15a.465.465 0 0 1-.69.4L2.54 12.4a.46.46 0 0 1 0-.8l8.77-5.08c.07-.04.15-.06.23-.06Z'
-                  />
-                  <path d='M.92 24H0v-6.46h.92z' />
-                  <path d='M16 24h-.92V0H16zM.92 24H0V0h.92z' />
-                  <path d='M16 23.08V24H0v-.92zM16 0v.92H0V0z' />
-                </svg>
-              </div>
-            </div>
+            <SliderThumb
+              @position='upper'
+              @twoHandles={{this.twoHandles}}
+              @style={{this.upperThumbStyle}}
+              @disabled={{@disabled}}
+              @readOnly={{@readOnly}}
+              @ariaValueMax={{@max}}
+              @ariaValueMin={{@value}}
+              @ariaValueNow={{@valueUpper}}
+              @ariaLabel={{@ariaLabelInputUpper}}
+              @onFocus={{this.onUpperFocus}}
+              @registerElement={{this.registerUpperThumb}}
+            />
           {{/if}}
 
           <div class='cds--slider__track'></div>
@@ -557,59 +498,27 @@ export default class Slider extends Component<SliderSignature> {
 
         <span class='cds--slider__range-label'>{{this.formatLabel @max @maxLabel}}</span>
 
-        <div
-          class='cds--text-input-wrapper cds--slider-text-input-wrapper
-            {{if this.twoHandles "cds--slider-text-input-wrapper--upper"}}
-            {{if @readOnly "cds--text-input-wrapper--readonly"}}
-            {{if @hideTextInput "cds--slider-text-input-wrapper--hidden"}}'
-        >
-          {{! template-lint-disable require-input-label }}
-          <input
-            type={{if @hideTextInput "hidden" "number"}}
-            id='{{this.id}}-{{if this.twoHandles "upper-"}}input-for-slider'
-            name={{if this.twoHandles @nameUpper @name}}
-            class='cds--text-input cds--slider-text-input
-              {{if this.twoHandles "cds--slider-text-input--upper"}}
-              {{if @invalid "cds--text-input--invalid"}}'
-            value={{this.upperDisplayValue}}
-            aria-labelledby={{if
-              (and (not @ariaLabelInput) (not this.twoHandles))
-              (concat this.id "-label")
-            }}
-            aria-label={{if this.twoHandles @ariaLabelInputUpper @ariaLabelInput}}
-            disabled={{@disabled}}
-            required={{@required}}
-            min={{@min}}
-            max={{@max}}
-            step={{@step}}
-            readonly={{@readOnly}}
-            aria-invalid={{if @invalid "true"}}
-            {{on
-              'change'
-              (fn this.onInputChange (if this.twoHandles 'upper' 'lower'))
-            }}
-            {{on
-              'input'
-              (fn this.onInputChange (if this.twoHandles 'upper' 'lower'))
-            }}
-            {{on
-              'blur'
-              (fn this.onInputBlur (if this.twoHandles 'upper' 'lower'))
-            }}
-            {{on
-              'keydown'
-              (fn this.onInputKeyDown (if this.twoHandles 'upper' 'lower'))
-            }}
-          />
-          {{#if @invalid}}
-            <WarningFilled @size='16' @svgClass='cds--slider__invalid-icon' />
-          {{else if @warn}}
-            <WarningAltFilled
-              @size='16'
-              @svgClass='cds--slider__invalid-icon cds--slider__invalid-icon--warning'
-            />
-          {{/if}}
-        </div>
+        <SliderTextInput
+          @handle={{if this.twoHandles 'upper' 'lower'}}
+          @suffix={{if this.twoHandles 'upper'}}
+          @id='{{this.id}}-{{if this.twoHandles "upper-"}}input-for-slider'
+          @name={{if this.twoHandles @nameUpper @name}}
+          @value={{this.upperDisplayValue}}
+          @ariaLabel={{if this.twoHandles @ariaLabelInputUpper @ariaLabelInput}}
+          @ariaLabelledby={{this.upperInputAriaLabelledby}}
+          @disabled={{@disabled}}
+          @required={{@required}}
+          @min={{@min}}
+          @max={{@max}}
+          @step={{@step}}
+          @readOnly={{@readOnly}}
+          @invalid={{@invalid}}
+          @warn={{@warn}}
+          @hideTextInput={{@hideTextInput}}
+          @onChange={{this.onInputChange}}
+          @onBlur={{this.onInputBlur}}
+          @onKeyDown={{this.onInputKeyDown}}
+        />
       </div>
       {{#if @invalid}}
         <div class='cds--slider__validation-msg cds--slider__validation-msg--invalid cds--form-requirement'>

--- a/carbon-components-ember/src/components/slider/-text-input.gts
+++ b/carbon-components-ember/src/components/slider/-text-input.gts
@@ -1,0 +1,87 @@
+/**
+ * Copyright IBM Corp. 2016, 2026
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import Component from '@glimmer/component';
+import { on } from '@ember/modifier';
+import { concat, fn } from '@ember/helper';
+import { WarningFilled, WarningAltFilled } from '../../icons.ts';
+import type { HandlePosition } from '../slider.gts';
+
+export interface SliderTextInputArgs {
+  handle: HandlePosition;
+  suffix?: string;
+  id: string;
+  name?: string;
+  value: string;
+  ariaLabel?: string;
+  ariaLabelledby?: string;
+  disabled?: boolean;
+  required?: boolean;
+  min: number;
+  max: number;
+  step?: number;
+  readOnly?: boolean;
+  invalid?: boolean;
+  warn?: boolean;
+  hideTextInput?: boolean;
+  onChange: (handle: HandlePosition, event: Event) => void;
+  onBlur: (handle: HandlePosition, event: FocusEvent) => void;
+  onKeyDown: (handle: HandlePosition, event: KeyboardEvent) => void;
+}
+
+export interface SliderTextInputSignature {
+  Args: SliderTextInputArgs;
+}
+
+/**
+ * Renders the number input alongside a slider handle. `Slider` invokes this
+ * twice (once per handle) with the differing bits — id, name, value,
+ * aria-label(ledby), and a `--lower`/`--upper` class suffix — already
+ * resolved, so the markup and event wiring only exist once.
+ */
+export default class SliderTextInput extends Component<SliderTextInputSignature> {
+  <template>
+    <div
+      class='cds--text-input-wrapper cds--slider-text-input-wrapper
+        {{if @suffix (concat "cds--slider-text-input-wrapper--" @suffix)}}
+        {{if @readOnly "cds--text-input-wrapper--readonly"}}
+        {{if @hideTextInput "cds--slider-text-input-wrapper--hidden"}}'
+    >
+      {{! template-lint-disable require-input-label }}
+      <input
+        type={{if @hideTextInput "hidden" "number"}}
+        id={{@id}}
+        name={{@name}}
+        class='cds--text-input cds--slider-text-input
+          {{if @suffix (concat "cds--slider-text-input--" @suffix)}}
+          {{if @invalid "cds--text-input--invalid"}}'
+        value={{@value}}
+        aria-label={{@ariaLabel}}
+        aria-labelledby={{@ariaLabelledby}}
+        disabled={{@disabled}}
+        required={{@required}}
+        min={{@min}}
+        max={{@max}}
+        step={{@step}}
+        readonly={{@readOnly}}
+        aria-invalid={{if @invalid "true"}}
+        {{on 'change' (fn @onChange @handle)}}
+        {{on 'input' (fn @onChange @handle)}}
+        {{on 'blur' (fn @onBlur @handle)}}
+        {{on 'keydown' (fn @onKeyDown @handle)}}
+      />
+      {{#if @invalid}}
+        <WarningFilled @size='16' @svgClass='cds--slider__invalid-icon' />
+      {{else if @warn}}
+        <WarningAltFilled
+          @size='16'
+          @svgClass='cds--slider__invalid-icon cds--slider__invalid-icon--warning'
+        />
+      {{/if}}
+    </div>
+  </template>
+}

--- a/carbon-components-ember/src/components/slider/-thumb.gts
+++ b/carbon-components-ember/src/components/slider/-thumb.gts
@@ -1,0 +1,131 @@
+/**
+ * Copyright IBM Corp. 2016, 2026
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import Component from '@glimmer/component';
+import { on } from '@ember/modifier';
+import { concat } from '@ember/helper';
+import type { SafeString } from '@ember/template';
+import { modifier } from 'ember-modifier';
+import { eq } from 'ember-truth-helpers';
+import type { HandlePosition } from '../slider.gts';
+
+const registerElement = modifier<{
+  Element: HTMLDivElement;
+  Args: { Positional: [(element: HTMLDivElement) => void] };
+}>((element, [onInsert]) => {
+  onInsert(element);
+});
+
+export interface SliderThumbArgs {
+  position: HandlePosition;
+  twoHandles: boolean;
+  style: SafeString;
+  id?: string;
+  disabled?: boolean;
+  readOnly?: boolean;
+  ariaValueText?: string;
+  ariaValueMax?: number;
+  ariaValueMin?: number;
+  ariaValueNow?: number;
+  ariaLabel?: string;
+  ariaLabelledby?: string;
+  onFocus: () => void;
+  registerElement: (element: HTMLDivElement) => void;
+}
+
+export interface SliderThumbSignature {
+  Args: SliderThumbArgs;
+}
+
+/**
+ * Renders a single slider handle (thumb), used once per handle position by
+ * `Slider`. The lower and upper handles differ only in a `--lower`/`--upper`
+ * class suffix and which resolved values each reads, so `Slider` resolves
+ * those differences into plain args and this component only renders markup.
+ */
+export default class SliderThumb extends Component<SliderThumbSignature> {
+  get suffix() {
+    return this.args.twoHandles ? this.args.position : '';
+  }
+
+  get tabindex() {
+    return this.args.readOnly || this.args.disabled ? undefined : 0;
+  }
+
+  <template>
+    <div
+      class='cds--icon-tooltip cds--slider__thumb-wrapper
+        {{if this.suffix (concat "cds--slider__thumb-wrapper--" this.suffix)}}'
+      style={{@style}}
+    >
+      {{! template-lint-disable require-presentational-children }}
+      <div
+        class='cds--slider__thumb
+          {{if this.suffix (concat "cds--slider__thumb--" this.suffix)}}'
+        role='slider'
+        id={{@id}}
+        tabindex={{this.tabindex}}
+        aria-valuetext={{@ariaValueText}}
+        aria-valuemax={{@ariaValueMax}}
+        aria-valuemin={{@ariaValueMin}}
+        aria-valuenow={{@ariaValueNow}}
+        aria-labelledby={{@ariaLabelledby}}
+        aria-label={{@ariaLabel}}
+        {{registerElement @registerElement}}
+        {{on 'focus' @onFocus}}
+      >
+        {{#if @twoHandles}}
+          {{#if (eq @position 'lower')}}
+            <svg
+              xmlns='http://www.w3.org/2000/svg'
+              viewBox='0 0 16 24'
+              class='cds--slider__thumb-icon cds--slider__thumb-icon--lower'
+            >
+              <path
+                d='M15.08 6.46H16v11.08h-.92zM4.46 17.54c-.25 0-.46-.21-.46-.46V6.92a.465.465 0 0 1 .69-.4l8.77 5.08a.46.46 0 0 1 0 .8l-8.77 5.08c-.07.04-.15.06-.23.06Z'
+              />
+            </svg>
+            <svg
+              xmlns='http://www.w3.org/2000/svg'
+              viewBox='0 0 16 24'
+              class='cds--slider__thumb-icon cds--slider__thumb-icon--lower cds--slider__thumb-icon--focus'
+            >
+              <path
+                d='M15.08 6.46H16v11.08h-.92zM4.46 17.54c-.25 0-.46-.21-.46-.46V6.92a.465.465 0 0 1 .69-.4l8.77 5.08a.46.46 0 0 1 0 .8l-8.77 5.08c-.07.04-.15.06-.23.06Z'
+              />
+              <path d='M15.08 0H16v6.46h-.92z' />
+              <path d='M0 0h.92v24H0zM15.08 0H16v24h-.92z' />
+              <path d='M0 .92V0h16v.92zM0 24v-.92h16V24z' />
+            </svg>
+          {{else}}
+            <svg
+              xmlns='http://www.w3.org/2000/svg'
+              viewBox='0 0 16 24'
+              class='cds--slider__thumb-icon cds--slider__thumb-icon--upper'
+            >
+              <path
+                d='M0 6.46h.92v11.08H0zM11.54 6.46c.25 0 .46.21.46.46v10.15a.465.465 0 0 1-.69.4L2.54 12.4a.46.46 0 0 1 0-.8l8.77-5.08c.07-.04.15-.06.23-.06Z'
+              />
+            </svg>
+            <svg
+              xmlns='http://www.w3.org/2000/svg'
+              viewBox='0 0 16 24'
+              class='cds--slider__thumb-icon cds--slider__thumb-icon--upper cds--slider__thumb-icon--focus'
+            >
+              <path
+                d='M0 6.46h.92v11.08H0zM11.54 6.46c.25 0 .46.21.46.46v10.15a.465.465 0 0 1-.69.4L2.54 12.4a.46.46 0 0 1 0-.8l8.77-5.08c.07-.04.15-.06.23-.06Z'
+              />
+              <path d='M.92 24H0v-6.46h.92z' />
+              <path d='M16 24h-.92V0H16zM.92 24H0V0h.92z' />
+              <path d='M16 23.08V24H0v-.92zM16 0v.92H0V0z' />
+            </svg>
+          {{/if}}
+        {{/if}}
+      </div>
+    </div>
+  </template>
+}

--- a/test-app/tests/__snapshots__/integration-|-component-|-slider/dark-theme:-should-display-slider/should-correctly-switch-to-dark-styles.json
+++ b/test-app/tests/__snapshots__/integration-|-component-|-slider/dark-theme:-should-display-slider/should-correctly-switch-to-dark-styles.json
@@ -172,7 +172,7 @@
     }
   ],
   [
-    "<div class=\"cds--icon-tooltip cds--slider__thumb-wrapper\n              \" style=\"inset-inline-start: 50%;\" data-index=\"5\"></div>",
+    "<div class=\"cds--icon-tooltip cds--slider__thumb-wrapper\n        \" style=\"inset-inline-start: 50%;\" data-index=\"5\"></div>",
     {
       "border": "0px none rgb(244, 244, 244)",
       "bottom": "2px",
@@ -191,7 +191,7 @@
     }
   ],
   [
-    "<div:before class=\"cds--icon-tooltip cds--slider__thumb-wrapper\n              \" style=\"inset-inline-start: 50%;\" data-index=\"5\"></div:before>",
+    "<div:before class=\"cds--icon-tooltip cds--slider__thumb-wrapper\n        \" style=\"inset-inline-start: 50%;\" data-index=\"5\"></div:before>",
     {
       "border": "0px none rgb(244, 244, 244)",
       "color": "rgb(244, 244, 244)",
@@ -201,7 +201,7 @@
     }
   ],
   [
-    "<div:after class=\"cds--icon-tooltip cds--slider__thumb-wrapper\n              \" style=\"inset-inline-start: 50%;\" data-index=\"5\"></div:after>",
+    "<div:after class=\"cds--icon-tooltip cds--slider__thumb-wrapper\n        \" style=\"inset-inline-start: 50%;\" data-index=\"5\"></div:after>",
     {
       "border": "0px none rgb(244, 244, 244)",
       "color": "rgb(244, 244, 244)",
@@ -211,7 +211,7 @@
     }
   ],
   [
-    "<div class=\"cds--slider__thumb \" role=\"slider\" id=\"slider-ember123\" tabindex=\"0\" aria-valuetext=\"50\" aria-valuemax=\"100\" aria-valuemin=\"0\" aria-valuenow=\"50\" aria-labelledby=\"slider-ember123-label\" data-index=\"6\"></div>",
+    "<div class=\"cds--slider__thumb\n          \" role=\"slider\" id=\"slider-ember123\" tabindex=\"0\" aria-valuetext=\"50\" aria-valuemax=\"100\" aria-valuemin=\"0\" aria-valuenow=\"50\" aria-labelledby=\"slider-ember123-label\" data-index=\"6\"></div>",
     {
       "background": "rgb(244, 244, 244) none repeat scroll 0% 0% / auto padding-box border-box",
       "border": "0px none rgb(244, 244, 244)",
@@ -231,7 +231,7 @@
     }
   ],
   [
-    "<div:before class=\"cds--slider__thumb \" role=\"slider\" id=\"slider-ember123\" tabindex=\"0\" aria-valuetext=\"50\" aria-valuemax=\"100\" aria-valuemin=\"0\" aria-valuenow=\"50\" aria-labelledby=\"slider-ember123-label\" data-index=\"6\"></div:before>",
+    "<div:before class=\"cds--slider__thumb\n          \" role=\"slider\" id=\"slider-ember123\" tabindex=\"0\" aria-valuetext=\"50\" aria-valuemax=\"100\" aria-valuemin=\"0\" aria-valuenow=\"50\" aria-labelledby=\"slider-ember123-label\" data-index=\"6\"></div:before>",
     {
       "border": "0px none rgb(244, 244, 244)",
       "color": "rgb(244, 244, 244)",
@@ -241,7 +241,7 @@
     }
   ],
   [
-    "<div:after class=\"cds--slider__thumb \" role=\"slider\" id=\"slider-ember123\" tabindex=\"0\" aria-valuetext=\"50\" aria-valuemax=\"100\" aria-valuemin=\"0\" aria-valuenow=\"50\" aria-labelledby=\"slider-ember123-label\" data-index=\"6\"></div:after>",
+    "<div:after class=\"cds--slider__thumb\n          \" role=\"slider\" id=\"slider-ember123\" tabindex=\"0\" aria-valuetext=\"50\" aria-valuemax=\"100\" aria-valuemin=\"0\" aria-valuenow=\"50\" aria-labelledby=\"slider-ember123-label\" data-index=\"6\"></div:after>",
     {
       "border": "0px none rgb(244, 244, 244)",
       "color": "rgb(244, 244, 244)",
@@ -374,7 +374,7 @@
     }
   ],
   [
-    "<div class=\"cds--text-input-wrapper cds--slider-text-input-wrapper\n            \n            \n            \" data-index=\"10\"></div>",
+    "<div class=\"cds--text-input-wrapper cds--slider-text-input-wrapper\n        \n        \n        \" data-index=\"10\"></div>",
     {
       "border": "0px none rgb(244, 244, 244)",
       "bottom": "0px",
@@ -391,7 +391,7 @@
     }
   ],
   [
-    "<div:before class=\"cds--text-input-wrapper cds--slider-text-input-wrapper\n            \n            \n            \" data-index=\"10\"></div:before>",
+    "<div:before class=\"cds--text-input-wrapper cds--slider-text-input-wrapper\n        \n        \n        \" data-index=\"10\"></div:before>",
     {
       "border": "0px none rgb(244, 244, 244)",
       "color": "rgb(244, 244, 244)",
@@ -400,7 +400,7 @@
     }
   ],
   [
-    "<div:after class=\"cds--text-input-wrapper cds--slider-text-input-wrapper\n            \n            \n            \" data-index=\"10\"></div:after>",
+    "<div:after class=\"cds--text-input-wrapper cds--slider-text-input-wrapper\n        \n        \n        \" data-index=\"10\"></div:after>",
     {
       "border": "0px none rgb(244, 244, 244)",
       "color": "rgb(244, 244, 244)",
@@ -409,7 +409,7 @@
     }
   ],
   [
-    "<input id=\"slider-ember123-input-for-slider\" class=\"cds--text-input cds--slider-text-input\n              \n              \" aria-labelledby=\"slider-ember123-label\" min=\"0\" max=\"100\" type=\"number\" data-index=\"11\"></input>",
+    "<input id=\"slider-ember123-input-for-slider\" class=\"cds--text-input cds--slider-text-input\n          \n          \" aria-labelledby=\"slider-ember123-label\" min=\"0\" max=\"100\" type=\"number\" data-index=\"11\"></input>",
     {
       "appearance": "textfield",
       "background": "rgb(57, 57, 57) none repeat scroll 0% 0% / auto padding-box border-box",
@@ -424,7 +424,7 @@
     }
   ],
   [
-    "<input:before id=\"slider-ember123-input-for-slider\" class=\"cds--text-input cds--slider-text-input\n              \n              \" aria-labelledby=\"slider-ember123-label\" min=\"0\" max=\"100\" type=\"number\" data-index=\"11\"></input:before>",
+    "<input:before id=\"slider-ember123-input-for-slider\" class=\"cds--text-input cds--slider-text-input\n          \n          \" aria-labelledby=\"slider-ember123-label\" min=\"0\" max=\"100\" type=\"number\" data-index=\"11\"></input:before>",
     {
       "border": "0px none rgb(244, 244, 244)",
       "color": "rgb(244, 244, 244)",
@@ -433,7 +433,7 @@
     }
   ],
   [
-    "<input:after id=\"slider-ember123-input-for-slider\" class=\"cds--text-input cds--slider-text-input\n              \n              \" aria-labelledby=\"slider-ember123-label\" min=\"0\" max=\"100\" type=\"number\" data-index=\"11\"></input:after>",
+    "<input:after id=\"slider-ember123-input-for-slider\" class=\"cds--text-input cds--slider-text-input\n          \n          \" aria-labelledby=\"slider-ember123-label\" min=\"0\" max=\"100\" type=\"number\" data-index=\"11\"></input:after>",
     {
       "border": "0px none rgb(244, 244, 244)",
       "color": "rgb(244, 244, 244)",

--- a/test-app/tests/__snapshots__/integration-|-component-|-slider/white-theme:-should-display-slider/should-have-correct-initial-styles.json
+++ b/test-app/tests/__snapshots__/integration-|-component-|-slider/white-theme:-should-display-slider/should-have-correct-initial-styles.json
@@ -172,7 +172,7 @@
     }
   ],
   [
-    "<div class=\"cds--icon-tooltip cds--slider__thumb-wrapper\n              \" style=\"inset-inline-start: 50%;\" data-index=\"5\"></div>",
+    "<div class=\"cds--icon-tooltip cds--slider__thumb-wrapper\n        \" style=\"inset-inline-start: 50%;\" data-index=\"5\"></div>",
     {
       "border": "0px none rgb(22, 22, 22)",
       "bottom": "2px",
@@ -191,7 +191,7 @@
     }
   ],
   [
-    "<div:before class=\"cds--icon-tooltip cds--slider__thumb-wrapper\n              \" style=\"inset-inline-start: 50%;\" data-index=\"5\"></div:before>",
+    "<div:before class=\"cds--icon-tooltip cds--slider__thumb-wrapper\n        \" style=\"inset-inline-start: 50%;\" data-index=\"5\"></div:before>",
     {
       "border": "0px none rgb(22, 22, 22)",
       "color": "rgb(22, 22, 22)",
@@ -201,7 +201,7 @@
     }
   ],
   [
-    "<div:after class=\"cds--icon-tooltip cds--slider__thumb-wrapper\n              \" style=\"inset-inline-start: 50%;\" data-index=\"5\"></div:after>",
+    "<div:after class=\"cds--icon-tooltip cds--slider__thumb-wrapper\n        \" style=\"inset-inline-start: 50%;\" data-index=\"5\"></div:after>",
     {
       "border": "0px none rgb(22, 22, 22)",
       "color": "rgb(22, 22, 22)",
@@ -211,7 +211,7 @@
     }
   ],
   [
-    "<div class=\"cds--slider__thumb \" role=\"slider\" id=\"slider-ember123\" tabindex=\"0\" aria-valuetext=\"50\" aria-valuemax=\"100\" aria-valuemin=\"0\" aria-valuenow=\"50\" aria-labelledby=\"slider-ember123-label\" data-index=\"6\"></div>",
+    "<div class=\"cds--slider__thumb\n          \" role=\"slider\" id=\"slider-ember123\" tabindex=\"0\" aria-valuetext=\"50\" aria-valuemax=\"100\" aria-valuemin=\"0\" aria-valuenow=\"50\" aria-labelledby=\"slider-ember123-label\" data-index=\"6\"></div>",
     {
       "background": "rgb(22, 22, 22) none repeat scroll 0% 0% / auto padding-box border-box",
       "border": "0px none rgb(22, 22, 22)",
@@ -231,7 +231,7 @@
     }
   ],
   [
-    "<div:before class=\"cds--slider__thumb \" role=\"slider\" id=\"slider-ember123\" tabindex=\"0\" aria-valuetext=\"50\" aria-valuemax=\"100\" aria-valuemin=\"0\" aria-valuenow=\"50\" aria-labelledby=\"slider-ember123-label\" data-index=\"6\"></div:before>",
+    "<div:before class=\"cds--slider__thumb\n          \" role=\"slider\" id=\"slider-ember123\" tabindex=\"0\" aria-valuetext=\"50\" aria-valuemax=\"100\" aria-valuemin=\"0\" aria-valuenow=\"50\" aria-labelledby=\"slider-ember123-label\" data-index=\"6\"></div:before>",
     {
       "border": "0px none rgb(22, 22, 22)",
       "color": "rgb(22, 22, 22)",
@@ -241,7 +241,7 @@
     }
   ],
   [
-    "<div:after class=\"cds--slider__thumb \" role=\"slider\" id=\"slider-ember123\" tabindex=\"0\" aria-valuetext=\"50\" aria-valuemax=\"100\" aria-valuemin=\"0\" aria-valuenow=\"50\" aria-labelledby=\"slider-ember123-label\" data-index=\"6\"></div:after>",
+    "<div:after class=\"cds--slider__thumb\n          \" role=\"slider\" id=\"slider-ember123\" tabindex=\"0\" aria-valuetext=\"50\" aria-valuemax=\"100\" aria-valuemin=\"0\" aria-valuenow=\"50\" aria-labelledby=\"slider-ember123-label\" data-index=\"6\"></div:after>",
     {
       "border": "0px none rgb(22, 22, 22)",
       "color": "rgb(22, 22, 22)",
@@ -374,7 +374,7 @@
     }
   ],
   [
-    "<div class=\"cds--text-input-wrapper cds--slider-text-input-wrapper\n            \n            \n            \" data-index=\"10\"></div>",
+    "<div class=\"cds--text-input-wrapper cds--slider-text-input-wrapper\n        \n        \n        \" data-index=\"10\"></div>",
     {
       "border": "0px none rgb(22, 22, 22)",
       "bottom": "0px",
@@ -391,7 +391,7 @@
     }
   ],
   [
-    "<div:before class=\"cds--text-input-wrapper cds--slider-text-input-wrapper\n            \n            \n            \" data-index=\"10\"></div:before>",
+    "<div:before class=\"cds--text-input-wrapper cds--slider-text-input-wrapper\n        \n        \n        \" data-index=\"10\"></div:before>",
     {
       "border": "0px none rgb(22, 22, 22)",
       "color": "rgb(22, 22, 22)",
@@ -400,7 +400,7 @@
     }
   ],
   [
-    "<div:after class=\"cds--text-input-wrapper cds--slider-text-input-wrapper\n            \n            \n            \" data-index=\"10\"></div:after>",
+    "<div:after class=\"cds--text-input-wrapper cds--slider-text-input-wrapper\n        \n        \n        \" data-index=\"10\"></div:after>",
     {
       "border": "0px none rgb(22, 22, 22)",
       "color": "rgb(22, 22, 22)",
@@ -409,7 +409,7 @@
     }
   ],
   [
-    "<input id=\"slider-ember123-input-for-slider\" class=\"cds--text-input cds--slider-text-input\n              \n              \" aria-labelledby=\"slider-ember123-label\" min=\"0\" max=\"100\" type=\"number\" data-index=\"11\"></input>",
+    "<input id=\"slider-ember123-input-for-slider\" class=\"cds--text-input cds--slider-text-input\n          \n          \" aria-labelledby=\"slider-ember123-label\" min=\"0\" max=\"100\" type=\"number\" data-index=\"11\"></input>",
     {
       "appearance": "textfield",
       "background": "rgb(244, 244, 244) none repeat scroll 0% 0% / auto padding-box border-box",
@@ -424,7 +424,7 @@
     }
   ],
   [
-    "<input:before id=\"slider-ember123-input-for-slider\" class=\"cds--text-input cds--slider-text-input\n              \n              \" aria-labelledby=\"slider-ember123-label\" min=\"0\" max=\"100\" type=\"number\" data-index=\"11\"></input:before>",
+    "<input:before id=\"slider-ember123-input-for-slider\" class=\"cds--text-input cds--slider-text-input\n          \n          \" aria-labelledby=\"slider-ember123-label\" min=\"0\" max=\"100\" type=\"number\" data-index=\"11\"></input:before>",
     {
       "border": "0px none rgb(22, 22, 22)",
       "color": "rgb(22, 22, 22)",
@@ -433,7 +433,7 @@
     }
   ],
   [
-    "<input:after id=\"slider-ember123-input-for-slider\" class=\"cds--text-input cds--slider-text-input\n              \n              \" aria-labelledby=\"slider-ember123-label\" min=\"0\" max=\"100\" type=\"number\" data-index=\"11\"></input:after>",
+    "<input:after id=\"slider-ember123-input-for-slider\" class=\"cds--text-input cds--slider-text-input\n          \n          \" aria-labelledby=\"slider-ember123-label\" min=\"0\" max=\"100\" type=\"number\" data-index=\"11\"></input:after>",
     {
       "border": "0px none rgb(22, 22, 22)",
       "color": "rgb(22, 22, 22)",


### PR DESCRIPTION
## Summary
- Migrates `Slider` off `@ember/render-modifiers` (`did-insert`), replacing the track/thumb element captures with a plain `ember-modifier` function.
- Extracts the near-duplicate lower/upper handle markup (SVG thumb icon pairs and text-input wrapper blocks, previously written out twice differing only by a `--lower`/`--upper` class suffix and which arg each read) into two private sub-components, `slider/-thumb.gts` and `slider/-text-input.gts`, each invoked twice with the differing bits already resolved into plain args — the same shape `tree-view/-node.gts`/`data-table/-header.gts` already use.
- Updates `AGENTS.md`'s render-modifiers inventory and "Known Codebase Debt" entry to reflect `slider.gts` being done.

This is one of several follow-up PRs migrating the remaining `@ember/render-modifiers` users named in AGENTS.md's audit (2026-09-09); the other 6 (`charts/-components/chart.gts`, `data-table.gts`, `pagination.gts`, `popover.gts`, `select.gts`, `tooltip.gts`) are tracked separately.

No behavior change: the two affected style-snapshot fixtures were regenerated to account for whitespace-only differences in the rendered `class` attribute (a byproduct of the markup now living in a different template file), not any real style/DOM difference — verified by diffing the computed-style values, which are unchanged.

## Test plan
- [x] `pnpm build:js` (addon)
- [x] `pnpm exec glint` / `pnpm run lint` (0 errors)
- [x] `test-app` full suite: 657/657 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)