### PR TITLE
refactor: migrate DataTable and Pagination off @ember/render-modifiers

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -509,13 +509,14 @@ for the reader of the docs site, not for yourself.
   It observes render rather than state, doesn't compose, and has no teardown
   story. Write a real modifier instead (§4). As of the 2026-09-09 audit,
   13 components still imported it; `checkbox.gts`, `code-snippet.gts`,
-  `list.gts`, `ordered-list.gts`, `search.gts`, `toggletip.gts`, and
-  `slider.gts` have since been migrated off it. 6 components still import
-  it: `charts/-components/chart.gts`, `data-table.gts`, `pagination.gts`,
-  `popover.gts`, `select.gts`, `tooltip.gts`. Migrating one of these to a
-  real modifier while you're already touching it for something else is
-  in-scope cleanup, not scope creep — don't do a drive-by rewrite of an
-  unrelated file just to cross it off this list.
+  `list.gts`, `ordered-list.gts`, `search.gts`, `toggletip.gts`,
+  `slider.gts`, `data-table.gts`, and `pagination.gts` have since been
+  migrated off it. 4 components still import it:
+  `charts/-components/chart.gts`, `popover.gts`, `select.gts`,
+  `tooltip.gts`. Migrating one of these to a real modifier while you're
+  already touching it for something else is in-scope cleanup, not scope
+  creep — don't do a drive-by rewrite of an unrelated file just to cross
+  it off this list.
 - **An ad-hoc `willDestroy()` lifecycle override** instead of
   `registerDestructor` or a modifier's own teardown function (see §6).
   `ordered-list.gts`'s has since been replaced with a modifier teardown; one

--- a/carbon-components-ember/src/components/data-table.gts
+++ b/carbon-components-ember/src/components/data-table.gts
@@ -6,7 +6,7 @@ import { default as Table } from './data-table/-table.gts';
 import { default as Pagination } from './pagination.gts';
 import { default as SearchInput } from './data-table/-search-input.gts';
 import { default as Menu } from './data-table/-menu.gts';
-import { default as didInsert } from '@ember/render-modifiers/modifiers/did-insert';
+import { modifier } from 'ember-modifier';
 import Component from '@glimmer/component';
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
@@ -221,10 +221,9 @@ export default class DataTableComponent<T> extends Component<
     return this.state.selectedItems.hasAll(this.currentItems);
   }
 
-  @action
-  didInsert() {
+  notifyRegisterState = modifier(() => {
     runTask(this, () => this.args.registerState?.(this.state));
-  }
+  });
 
   @action
   search(term?: string) {
@@ -268,7 +267,7 @@ export default class DataTableComponent<T> extends Component<
       class='cds--data-table-container {{if @isLoading "bx-skeleton"}}'
       data-table
     >
-      <div class='cds--data-table-header' {{didInsert this.didInsert}}>
+      <div class='cds--data-table-header' {{this.notifyRegisterState}}>
         <h4 class='cds--data-table-header__title'>
           {{@title}}
         </h4>

--- a/carbon-components-ember/src/components/pagination.gts
+++ b/carbon-components-ember/src/components/pagination.gts
@@ -2,9 +2,8 @@ import { default as Select } from './select.gts';
 import { default as Tooltip } from './tooltip.gts';
 import { default as defaultTo } from '../helpers/default-to.ts';
 import { default as eq } from 'ember-truth-helpers/helpers/eq';
-import { default as didInsert } from '@ember/render-modifiers/modifiers/did-insert';
-import { default as didUpdate } from '@ember/render-modifiers/modifiers/did-update';
-import { array, concat, fn } from '@ember/helper';
+import { modifier } from 'ember-modifier';
+import { array, concat } from '@ember/helper';
 import { on } from '@ember/modifier';
 import { default as or } from 'ember-truth-helpers/helpers/or';
 import Component from '@glimmer/component';
@@ -161,6 +160,21 @@ export default class CarbonPagination extends Component<Args> {
     }
   }
 
+  notifyInitialPage = modifier(() => {
+    this.pageChanged();
+  });
+
+  syncedInitialState = false;
+
+  syncState = modifier(() => {
+    const state = this.args.state;
+    if (!this.syncedInitialState) {
+      this.syncedInitialState = true;
+      return;
+    }
+    this.setState(state);
+  });
+
   styles = stylesheet`
     .namespace {
       width: 100%;
@@ -188,8 +202,8 @@ export default class CarbonPagination extends Component<Args> {
         {{this.styles.namespace}}
         {{if @isLoading "cds--skeleton"}}'
       data-pagination
-      {{didInsert this.pageChanged}}
-      {{didUpdate (fn this.setState @state) @state}}
+      {{this.notifyInitialPage}}
+      {{this.syncState}}
     >
       {{#if @isLoading}}
         <div class='cds--skeleton__text'></div>


### PR DESCRIPTION
## Summary
- `DataTable`'s one-shot `registerState` notification (previously `{{didInsert this.didInsert}}`) is now a plain `ember-modifier` function (`notifyRegisterState`) that reads no tracked state synchronously, so it fires exactly once on insert — same semantics as `did-insert`.
- `Pagination`'s two render-modifiers hooks become two separate `ember-modifier` functions:
  - `notifyInitialPage` replaces `{{didInsert this.pageChanged}}` (fires once on insert).
  - `syncState` replaces `{{didUpdate (fn this.setState @state) @state}}` — it reads `@state` on every invocation (to establish the tracked dependency so it reruns whenever `@state` changes) but explicitly skips acting on the very first invocation, replicating `did-update`'s "never fires on the initial render" behavior. Without that guard, a controlled `@state` prop would get double-applied — once from the natural component setup, once redundantly from the modifier's first run.
- Updates `AGENTS.md`'s render-modifiers inventory to reflect both being done.

This is one of several follow-up PRs migrating the remaining `@ember/render-modifiers` users named in AGENTS.md's audit (2026-09-09); the other 4 (`charts/-components/chart.gts`, `popover.gts`, `select.gts`, `tooltip.gts`) are tracked separately, along with `slider.gts` (#845, already open).

No behavior change — verified via the full test-app suite, including Pagination's existing "clicking forward/backward changes the current page" coverage.

## Test plan
- [x] `pnpm build:js` (addon)
- [x] `pnpm exec glint` / `pnpm run lint` (0 errors)
- [x] `test-app` full suite: 657/657 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)