### PR TITLE
refactor: migrate Tooltip off @ember/render-modifiers

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -510,13 +510,12 @@ for the reader of the docs site, not for yourself.
   story. Write a real modifier instead (§4). As of the 2026-09-09 audit,
   13 components still imported it; `checkbox.gts`, `code-snippet.gts`,
   `list.gts`, `ordered-list.gts`, `search.gts`, `toggletip.gts`,
-  `slider.gts`, `data-table.gts`, and `pagination.gts` have since been
-  migrated off it. 4 components still import it:
-  `charts/-components/chart.gts`, `popover.gts`, `select.gts`,
-  `tooltip.gts`. Migrating one of these to a real modifier while you're
-  already touching it for something else is in-scope cleanup, not scope
-  creep — don't do a drive-by rewrite of an unrelated file just to cross
-  it off this list.
+  `slider.gts`, `data-table.gts`, `pagination.gts`, and `tooltip.gts` have
+  since been migrated off it. 3 components still import it:
+  `charts/-components/chart.gts`, `popover.gts`, `select.gts`. Migrating
+  one of these to a real modifier while you're already touching it for
+  something else is in-scope cleanup, not scope creep — don't do a
+  drive-by rewrite of an unrelated file just to cross it off this list.
 - **An ad-hoc `willDestroy()` lifecycle override** instead of
   `registerDestructor` or a modifier's own teardown function (see §6).
   `ordered-list.gts`'s has since been replaced with a modifier teardown; one

--- a/carbon-components-ember/src/components/tooltip.gts
+++ b/carbon-components-ember/src/components/tooltip.gts
@@ -12,8 +12,7 @@ import { action } from '@ember/object';
 import { guidFor } from '@ember/object/internals';
 import { registerDestructor } from '@ember/destroyable';
 import { on } from '@ember/modifier';
-import didInsert from '@ember/render-modifiers/modifiers/did-insert';
-import didUpdate from '@ember/render-modifiers/modifiers/did-update';
+import { modifier } from 'ember-modifier';
 import { defaultArgs } from '../utils/decorators.ts';
 import { scheduleTask } from 'ember-lifeline';
 
@@ -151,16 +150,10 @@ export default class CarbonTooltip extends Component<CarbonTooltipSignature> {
     return classes.join(' ');
   }
 
-  @action
-  setup(el: HTMLElement) {
-    this.containerElement = el;
+  manageAutoAlign = modifier((element: HTMLElement) => {
+    this.containerElement = element;
     this.updateAutoAlign();
-  }
-
-  @action
-  update() {
-    this.updateAutoAlign();
-  }
+  });
 
   updateAutoAlign() {
     if (!this.args.autoAlign || !this.open || !this.containerElement) {
@@ -260,8 +253,7 @@ export default class CarbonTooltip extends Component<CarbonTooltipSignature> {
     <span
       class={{this.classes}}
       ...attributes
-      {{didInsert this.setup}}
-      {{didUpdate this.update this.open @align}}
+      {{this.manageAutoAlign}}
       {{on 'mouseenter' this.onMouseEnter}}
       {{on 'mouseleave' this.onMouseLeave}}
       {{on 'focusin' this.onFocusIn}}


### PR DESCRIPTION
## Summary
- `Tooltip`'s `{{didInsert this.setup}}` + `{{didUpdate this.update this.open @align}}` pair becomes a single `ember-modifier` (`manageAutoAlign`) that assigns `containerElement` and calls `updateAutoAlign()` directly — the same shape already established in `menu.gts`'s `positionMenu` modifier: read whatever state you need inside the modifier body and let autotracking handle reruns, rather than hand-listing dependencies.
- One deliberate, minor behavior widening: the previous `did-update` only watched `this.open`/`@align`, so a live change to `@autoAlign`/`@autoAlignBoundary` after mount was silently ignored. The real modifier's autotracking now also reacts to those (since `updateAutoAlign()` reads them internally) — a strict improvement consistent with AGENTS.md's own rationale for migrating off render-modifiers ("it observes render rather than state"), not a deliberate behavior change to review around.
- Updates `AGENTS.md`'s render-modifiers inventory to reflect `tooltip.gts` being done.

This is one of several follow-up PRs migrating the remaining `@ember/render-modifiers` users named in AGENTS.md's audit (2026-09-09); the other 3 (`charts/-components/chart.gts`, `popover.gts`, `select.gts`) are tracked separately, along with `slider.gts` (#845) and `data-table.gts`/`pagination.gts` (#846), already open.

## Test plan
- [x] `pnpm build:js` (addon)
- [x] `pnpm exec glint` / `pnpm run lint` (0 errors)
- [x] `test-app` full suite: 657/657 passing, including both `@autoAlign` tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)