### PR TITLE
refactor: migrate Select off @ember/render-modifiers

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -510,13 +510,15 @@ for the reader of the docs site, not for yourself.
   story. Write a real modifier instead (§4). As of the 2026-09-09 audit,
   13 components still imported it; `checkbox.gts`, `code-snippet.gts`,
   `list.gts`, `ordered-list.gts`, `search.gts`, `toggletip.gts`,
-  `slider.gts`, `data-table.gts`, and `pagination.gts` have since been
-  migrated off it. 4 components still import it:
-  `charts/-components/chart.gts`, `popover.gts`, `select.gts`,
-  `tooltip.gts`. Migrating one of these to a real modifier while you're
-  already touching it for something else is in-scope cleanup, not scope
-  creep — don't do a drive-by rewrite of an unrelated file just to cross
-  it off this list.
+  `slider.gts`, `data-table.gts`, `pagination.gts`, and `select.gts` have
+  since been migrated off it (note: `select.gts` has no dedicated test
+  file — this and any future change to it is only covered indirectly, by
+  other components' tests that happen to render a `<Select>`). 3
+  components still import it: `charts/-components/chart.gts`,
+  `popover.gts`, `tooltip.gts`. Migrating one of these to a real modifier
+  while you're already touching it for something else is in-scope
+  cleanup, not scope creep — don't do a drive-by rewrite of an unrelated
+  file just to cross it off this list.
 - **An ad-hoc `willDestroy()` lifecycle override** instead of
   `registerDestructor` or a modifier's own teardown function (see §6).
   `ordered-list.gts`'s has since been replaced with a modifier teardown; one

--- a/carbon-components-ember/src/components/select.gts
+++ b/carbon-components-ember/src/components/select.gts
@@ -7,8 +7,7 @@ import PowerSelect, {
 } from 'ember-power-select/components/power-select';
 import type { ContentValue } from '@glint/template';
 import PowerSelectMultiple from 'ember-power-select/components/power-select-multiple';
-import didInsert from '@ember/render-modifiers/modifiers/did-insert';
-import didUpdate from '@ember/render-modifiers/modifiers/did-update';
+import { modifier } from 'ember-modifier';
 import defaultTo from '../helpers/default-to.ts';
 import Checkbox from '../components/checkbox.gts';
 import isSelected from 'ember-power-select/helpers/ember-power-select-is-equal';
@@ -68,8 +67,7 @@ type ExtractInterface<C> = C extends Component<infer T> ? T : unknown;
 type ArrayElement<A> = A extends readonly (infer T)[] ? T : never;
 type OptionsComponentInterface = ExtractInterface<OptionsComponent>;
 
-const addClassToParent = (el: HTMLElement, args: [string, boolean]) => {
-  const [cls, ifTrue] = args;
+const addClassToParent = (el: HTMLElement, cls: string, ifTrue: boolean) => {
   if (ifTrue !== false) {
     setTimeout(() => {
       el.parentElement?.classList.add(cls);
@@ -80,7 +78,21 @@ const addClassToParent = (el: HTMLElement, args: [string, boolean]) => {
       el.parentElement?.classList.remove(cls);
     });
   }
-}
+};
+
+const addMenuItemClass = modifier((element: HTMLElement) => {
+  addClassToParent(element, 'cds--list-box__menu-item', true);
+});
+
+const toggleHighlightedClass = modifier(
+  (element: HTMLElement, [highlighted]: [boolean]) => {
+    addClassToParent(
+      element,
+      'cds--list-box__menu-item--highlighted',
+      highlighted,
+    );
+  },
+);
 
 // eslint-disable-next-line @typescript-eslint/no-redundant-type-constituents
 const Options: TOC<OptionsComponentInterface & { Args: { guid: string } }> = <template>
@@ -245,9 +257,9 @@ export default class SelectComponent<T extends ContentValue> extends Component<
       this.args.select.actions.search((event.target as HTMLInputElement).value);
     }
 
-    focus = (element: HTMLElement) => {
+    focus = modifier((element: HTMLElement) => {
       element.focus();
-    }
+    });
 
       <template>
           {{#if @extra.title}}
@@ -308,7 +320,7 @@ export default class SelectComponent<T extends ContentValue> extends Component<
                   value=""
                   aria-controls="carbon-multiselect-{{this.guid}}__menu"
                   {{on 'input' this.doSearch}}
-                  {{didInsert this.focus}}
+                  {{this.focus}}
                 >
               {{/if}}
 
@@ -369,7 +381,7 @@ export default class SelectComponent<T extends ContentValue> extends Component<
         @closeOnSelect={{false}}
         as |option select|
       >
-        <div class='cds--list-box__menu-item__option' {{didUpdate addClassToParent  'cds--list-box__menu-item--highlighted' (eq option select.highlighted)}} {{didInsert addClassToParent 'cds--list-box__menu-item'}}>
+        <div class='cds--list-box__menu-item__option' {{toggleHighlightedClass (eq option select.highlighted)}} {{addMenuItemClass}}>
           <Checkbox
             @readonly={{true}}
             @checked={{isSelected option select.selected}}
@@ -410,7 +422,7 @@ export default class SelectComponent<T extends ContentValue> extends Component<
         @onChange={{this.onChange}}
         as |option select|
       >
-        <div class='cds--list-box__menu-item__option' {{didUpdate addClassToParent  'cds--list-box__menu-item--highlighted' (eq option select.highlighted)}} {{didInsert addClassToParent 'cds--list-box__menu-item'}}>
+        <div class='cds--list-box__menu-item__option' {{toggleHighlightedClass (eq option select.highlighted)}} {{addMenuItemClass}}>
           {{#if (isSelected option select.selected)}}
             <span style="font-weight: bold; position: absolute; margin-left: -14px;">&check;</span>
           {{/if}}


### PR DESCRIPTION
## Summary
- The search input's one-time focus-on-render (`{{didInsert this.focus}}`) becomes a modifier field (`focus`) that reads no tracked state, so it still runs exactly once, same as `did-insert`.
- The per-option `{{didUpdate addClassToParent ...}} {{didInsert addClassToParent ...}}` pair (used identically in both the `PowerSelectMultiple` and `PowerSelect` branches) — one call permanently adding `cds--list-box__menu-item` on insert, the other toggling `cds--list-box__menu-item--highlighted` whenever the option's highlighted state changes — becomes two small module-level `ember-modifier`s (`addMenuItemClass`, `toggleHighlightedClass`), both still delegating to the existing `addClassToParent` helper (only its signature changed from a 2-tuple to plain positional params).
- Updates `AGENTS.md`'s render-modifiers inventory to reflect `select.gts` being done, and flags (for future reference) that `select.gts` has no dedicated test file.

**Coverage note:** `select.gts` has no dedicated test file — this predates the migration and isn't something this PR fixes (would be scope creep for a render-modifiers-only change). The full test-app suite exercises `<Select>` indirectly through `Pagination`'s page-size control and `TimePickerSelect`, both still green, but neither opens the dropdown/interacts with options, so the two changed modifiers were verified by careful manual comparison against the original `did-insert`/`did-update` semantics rather than a new automated test.

This is one of several follow-up PRs migrating the remaining `@ember/render-modifiers` users named in AGENTS.md's audit (2026-09-09); the other 2 (`charts/-components/chart.gts`, `popover.gts`) are tracked separately, along with `slider.gts` (#845), `data-table.gts`/`pagination.gts` (#846), and `tooltip.gts` (#847), already open.

## Test plan
- [x] `pnpm build:js` (addon)
- [x] `pnpm exec glint` / `pnpm run lint` (0 errors)
- [x] `test-app` full suite: 657/657 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)