### PR TITLE
refactor: migrate Chart off @ember/render-modifiers, fix TabularData's ad-hoc willDestroy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -510,17 +510,18 @@ for the reader of the docs site, not for yourself.
   story. Write a real modifier instead (§4). As of the 2026-09-09 audit,
   13 components still imported it; `checkbox.gts`, `code-snippet.gts`,
   `list.gts`, `ordered-list.gts`, `search.gts`, `toggletip.gts`,
-  `slider.gts`, `data-table.gts`, and `pagination.gts` have since been
-  migrated off it. 4 components still import it:
-  `charts/-components/chart.gts`, `popover.gts`, `select.gts`,
-  `tooltip.gts`. Migrating one of these to a real modifier while you're
-  already touching it for something else is in-scope cleanup, not scope
-  creep — don't do a drive-by rewrite of an unrelated file just to cross
-  it off this list.
+  `slider.gts`, `data-table.gts`, `pagination.gts`, and
+  `charts/-components/chart.gts` have since been migrated off it. 3
+  components still import it: `popover.gts`, `select.gts`, `tooltip.gts`.
+  Migrating one of these to a real modifier while you're already touching
+  it for something else is in-scope cleanup, not scope creep — don't do a
+  drive-by rewrite of an unrelated file just to cross it off this list.
 - **An ad-hoc `willDestroy()` lifecycle override** instead of
-  `registerDestructor` or a modifier's own teardown function (see §6).
-  `ordered-list.gts`'s has since been replaced with a modifier teardown; one
-  component still does this: `charts/-components/tabular-data.gts`.
+  `registerDestructor` or a modifier's own teardown function (see §6). Two
+  components did this; both are now fixed — `ordered-list.gts`'s was
+  replaced with a modifier teardown, and `charts/-components/
+  tabular-data.gts` moved its `removeDataset` cleanup into a
+  `registerDestructor` call in its constructor.
 - **`A()` / `NativeArray` / `pushObject` / `removeObject`** and `set()` from
   `@ember/object`. Also present in older components. New code uses plain
   arrays/objects reassigned through `@tracked`. The legacy `bxClassNames`

--- a/carbon-components-ember/src/components/charts/-components/chart.gts
+++ b/carbon-components-ember/src/components/charts/-components/chart.gts
@@ -2,9 +2,7 @@ import { default as TabularData } from '../../charts/-components/tabular-data.gt
 import { default as Axis } from '../../charts/-components/axis.gts';
 import { default as ColorPairing } from '../../charts/-components/color/pairing.gts';
 import { default as ColorScale } from '../../charts/-components/color/scale.gts';
-import { default as didInsert } from '@ember/render-modifiers/modifiers/did-insert';
-import { default as didUpdate } from '@ember/render-modifiers/modifiers/did-update';
-import { default as willDestroy } from '@ember/render-modifiers/modifiers/will-destroy';
+import { modifier } from 'ember-modifier';
 import Component from '@glimmer/component';
 import { action } from '@ember/object';
 import { defaultArgs } from '../../../utils/decorators.ts';
@@ -144,6 +142,28 @@ export default class CarbonChart extends Component<CarbonChartSignature> {
     this.chart = undefined;
   }
 
+  loadChartModifier = modifier((element: HTMLDivElement) => {
+    this.loadChart(element);
+    return () => this.destroyChart();
+  });
+
+  hasUpdatedOnce = false;
+
+  updateChartModifier = modifier(
+    (_element: HTMLDivElement, [legendClickable, resizable]: [
+      boolean | undefined,
+      boolean | undefined,
+    ]) => {
+      void legendClickable;
+      void resizable;
+      if (!this.hasUpdatedOnce) {
+        this.hasUpdatedOnce = true;
+        return;
+      }
+      this.updateChart();
+    },
+  );
+
   @action
   setAxis(
     axis: 'left' | 'bottom',
@@ -209,9 +229,8 @@ export default class CarbonChart extends Component<CarbonChartSignature> {
   <template>
     <div
       ...attributes
-      {{didInsert this.loadChart}}
-      {{didUpdate this.updateChart @legendClickable @resizable}}
-      {{willDestroy this.destroyChart}}
+      {{this.loadChartModifier}}
+      {{this.updateChartModifier @legendClickable @resizable}}
     >
     </div>
 

--- a/carbon-components-ember/src/components/charts/-components/tabular-data.gts
+++ b/carbon-components-ember/src/components/charts/-components/tabular-data.gts
@@ -1,6 +1,8 @@
 import { default as onUpdate } from '../../charts/-helpers/on-update.ts';
 import Component from '@glimmer/component';
+import type Owner from '@ember/owner';
 import { action } from '@ember/object';
+import { registerDestructor } from '@ember/destroyable';
 import { defaultArgs } from '../../../utils/decorators.ts';
 import CarbonChart, {
   type ChartData,
@@ -48,6 +50,13 @@ export default class CarbonChartTabularData extends Component<Args> {
   private oldGroup?: string;
   defaultColor?: string[];
 
+  constructor(owner: Owner, args: Args) {
+    super(owner, args);
+    registerDestructor(this, () => {
+      this.args.chart?.removeDataset(this.oldGroup!);
+    });
+  }
+
   @action
   didUpdateArgs() {
     if (this.oldGroup && this.oldGroup !== this.args.group) {
@@ -74,11 +83,6 @@ export default class CarbonChartTabularData extends Component<Args> {
       this.args.backgroundColors || this.defaultColor || [],
       data,
     );
-  }
-
-  willDestroy() {
-    super.willDestroy();
-    this.args.chart?.removeDataset(this.oldGroup!);
   }
 
   <template>


### PR DESCRIPTION
## Summary
- `charts/-components/chart.gts`'s three `@ember/render-modifiers` hooks become two real `ember-modifier`s:
  - `loadChartModifier` combines `did-insert`'s one-time chart creation with `will-destroy`'s teardown — both only ever run once, so the modifier's own returned teardown function replaces the separate `{{willDestroy this.destroyChart}}`.
  - `updateChartModifier` replaces `did-update`. It explicitly reads `@legendClickable`/`@resizable` as positional args (so it tracks the same two dependencies `did-update` watched, not an expanded set) but skips its first invocation, replicating `did-update`'s "never fires on the initial render" behavior — the same guard already used for `Pagination`'s `syncState` modifier (#846). This distinction matters more here than elsewhere: a naive "just read args, let autotracking rerun the whole thing" modifier (the approach used for Popover/Tooltip, where it's harmless) would tear down and recreate the entire underlying `@carbon/charts` instance on every `@legendClickable`/`@resizable` change, instead of the cheap options/data update the original code performed.
- `charts/-components/tabular-data.gts`'s ad-hoc `willDestroy()` override — the other named exception in AGENTS.md's "What NOT to Reach For" list — is replaced with a `registerDestructor` call in its constructor, matching `ordered-list.gts`'s earlier fix for the same pitfall.
- Updates `AGENTS.md`'s render-modifiers and ad-hoc-`willDestroy` inventories to reflect both being done.

**Coverage note:** neither `chart.gts` nor `tabular-data.gts` has any test coverage (no `chart-test.gts` exists anywhere in the suite) — pre-existing, not something this PR fixes. This migration is verified by careful manual comparison against the original render-modifiers semantics (see the caveat above about not naively merging the update path), plus the full test-app suite, which is unaffected since it never exercises these files.

This is the last of the render-modifiers follow-ups covering the seven "higher-traffic" components from AGENTS.md's audit (2026-09-09), except `popover.gts` — tracked separately alongside the popover/toggletip outside-click unification, since it stacks on an unmerged sibling branch. Already open: `slider.gts` (#845), `data-table.gts`/`pagination.gts` (#846), `tooltip.gts` (#847), `select.gts` (#848).

## Test plan
- [x] `pnpm build:js` (addon)
- [x] `pnpm exec glint` / `pnpm run lint` (0 errors)
- [x] `test-app` full suite: 657/657 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)