### PR TITLE
fix: create/update Prepare Release PR even when release-plan is blocked

### DIFF
--- a/.github/workflows/plan-release.yml
+++ b/.github/workflows/plan-release.yml
@@ -66,18 +66,33 @@ jobs:
           set +e
 
           pnpm release-plan prepare 2> >(tee -a release-plan-stderr.txt >&2)
+          status=$?
 
-
-          if [ $? -ne 0 ]; then
+          if [ $status -ne 0 ]; then
             echo 'text<<EOF' >> $GITHUB_OUTPUT
             cat release-plan-stderr.txt >> $GITHUB_OUTPUT
             echo 'EOF' >> $GITHUB_OUTPUT
+            echo "status=blocked" >> $GITHUB_OUTPUT
+            # `release-plan prepare` exits before touching .release-plan.json/
+            # CHANGELOG.md/package.json when the plan is incomplete (e.g. some
+            # merged PRs are missing a semver label), so there is nothing left
+            # for create-pull-request to diff and it silently skips opening or
+            # updating the preview PR. Commit the explanation to a tracked
+            # placeholder file instead, so a PR still gets created/updated to
+            # surface which PRs need labels. Keep this filename clear of the
+            # ".release-plan.json" substring the release-trigger `grep -w -q`
+            # check below (and the same check in publish.yml) looks for, so
+            # merging this placeholder-only PR never fires a real release.
+            cp release-plan-stderr.txt .release-plan-pending.md
           else
             echo 'text<<EOF' >> $GITHUB_OUTPUT
             jq .description .release-plan.json -r >> $GITHUB_OUTPUT
             echo 'EOF' >> $GITHUB_OUTPUT
-            rm release-plan-stderr.txt
+            echo "status=ready" >> $GITHUB_OUTPUT
+            # plan is complete again; drop any stale pending-labels placeholder
+            rm -f .release-plan-pending.md
           fi
+          rm -f release-plan-stderr.txt
         env:
           GITHUB_AUTH: ${{ secrets.GITHUB_TOKEN }}
 
@@ -87,11 +102,11 @@ jobs:
           INPUT_COMMIT-MESSAGE: "Prepare Release using 'release-plan'"
           INPUT_LABELS: "internal"
           INPUT_BRANCH: release-preview
-          INPUT_TITLE: Prepare Release
+          INPUT_TITLE: "${{ steps.explanation.outputs.status == 'blocked' && 'Release Plan Incomplete' || 'Prepare Release' }}"
           INPUT_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           INPUT_AUTHOR: "${{ github.actor }} <${{ github.actor_id }}+${{ github.actor }}@users.noreply.github.com>"
           INPUT_BODY: |
-            This PR is a preview of the release that [release-plan](https://github.com/embroider-build/release-plan) has prepared. To release you should just merge this PR 👍
+            ${{ steps.explanation.outputs.status == 'blocked' && 'This PR is not ready to merge. release-plan could not compute the next release - see the explanation below for why, and what needs to change. This PR will update automatically once that is resolved and pushed to main.' || 'This PR is a preview of the release that [release-plan](https://github.com/embroider-build/release-plan) has prepared. To release you should just merge this PR 👍' }}
 
             -----------------------------------------
 

--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@ scripts/node_modules
 scripts/tmp
 !.gitconfig
 !.release-plan.json
+!.release-plan-pending.md
 !.parity-check-data.json
 !.parity-check-exclusions.json
 !PARITY_REPORT.md


### PR DESCRIPTION
## Summary
- `release-plan prepare` calls `process.exit(-1)` before writing `.release-plan.json`/`CHANGELOG.md`/`package.json` whenever a merged PR is missing a semver label (`plan.js`'s `planVersionBumps`), so the "Generate Explanation" step's own stderr capture already had the right text, but `create-pull-request` had zero tracked-file diff to work with and silently skipped opening/updating the `release-preview` PR. Confirmed against the real `Release Plan Review` workflow run from 2026-09-10 (PRs #845/#844/#841 unlabeled, run produced no PR).
- Fix: when `release-plan prepare` fails, write its explanation to a new tracked placeholder file, `.release-plan-pending.md` (allowlisted in `.gitignore`, which is otherwise `*` + allowlist), giving `create-pull-request` a real diff to commit. On a later successful run the placeholder is deleted again.
- The PR title/body are now conditional (`Release Plan Incomplete` vs `Prepare Release`) so this notification PR can't be mistaken for a mergeable release, regardless of which `release-plan prepare` failure produced it.
- Verified the new placeholder filename never satisfies the `grep -w -q ".release-plan.json"` release-trigger check in this workflow or in `publish.yml`, so merging this notification-only PR can never fire a real npm publish.

## Test plan
- [x] YAML parses (`yaml.safe_load`)
- [x] Extracted the step's shell logic into a standalone script and ran it against both a failing and a succeeding command locally: confirms `status=blocked`/`status=ready` outputs are well-formed and `.release-plan-pending.md` is created on failure and removed on success
- [x] `git check-ignore` / `git status` confirm `.release-plan-pending.md` is not swallowed by the root `.gitignore` wildcard
- [ ] The actual GitHub Actions path (`pull_request_target` with `labeled`/`unlabeled` on an already-merged PR, or `push` to `main`) can't be exercised from a fix branch — this needs verification once merged, by checking the next scheduled run against the currently-unlabeled #845/#844/#841.

🤖 Generated with [Claude Code](https://claude.com/claude-code)