### PR TITLE
fix: docs-app default 'white' theme never got real custom-property injection

### DIFF
--- a/docs-app/app/docs-support/theme-support.gts
+++ b/docs-app/app/docs-support/theme-support.gts
@@ -9,6 +9,7 @@ import * as uiShellStyle from 'carbon-components-ember/components/ui-shell/-side
 import * as carbonStyle from '@carbon/styles/css/styles.css?inline';
 import * as carbonChartsStyle from '@carbon/charts/styles.css?inline';
 
+import styleWhite from '../styles/carbon-white.scss?inline';
 import style10 from '../styles/carbon-gray-10.scss?inline';
 import style90 from '../styles/carbon-gray-90.scss?inline';
 import style100 from '../styles/carbon-gray-100.scss?inline';
@@ -32,7 +33,13 @@ export default class ThemeSwitcher extends GlimmerComponent {
         return style100 as unknown as string;
     }
 
-    return '';
+    // The default 'white' theme otherwise never gets a real :root/:host
+    // custom-property injection -- @carbon/styles' own color tokens are
+    // scoped under `.cds--white`, which nothing inside a shadow-wrapped
+    // demo ever carries. Without this, every demo silently falls back to
+    // its own hardcoded var(--cds-x, fallback) constant instead of a real
+    // resolved custom property.
+    return styleWhite as unknown as string;
   }
 
   <template>

--- a/docs-app/app/styles/carbon-white.scss
+++ b/docs-app/app/styles/carbon-white.scss
@@ -1,0 +1,10 @@
+@use '@carbon/themes/scss/themes' as *;
+@use '@carbon/themes' with (
+  $theme: $white
+);
+
+
+:host {
+  // Emit CSS Custom Properties for the current theme
+  @include themes.theme();
+}


### PR DESCRIPTION
## Summary
- `docs-app`'s `ThemeSupport` only emitted a real, Sass-recompiled `:root`/`:host`-scoped custom-property block for the g10/g90/g100 themes — the default **white** theme's `carbonTheme` getter fell through to `''`. `@carbon/styles`' own `--cds-*` color tokens are defined exclusively under `.cds--white`/`.cds--g10`/etc. class selectors, and nothing inside a `carbon-shadow-demo`'s shadow root ever carries one of those classes — so on the default theme, every live-preview demo silently fell back to its own hardcoded `var(--cds-x, fallback)` constant instead of a resolved custom property. This was invisible for most components only because their fallback happened to coincidentally equal the real white-theme value.
- Added `docs-app/app/styles/carbon-white.scss` (mirrors `carbon-gray-10.scss`, configured with `$theme: $white`) and wired it in as the default case of `ThemeSupport`'s `carbonTheme` getter.

## Test plan
- [x] Real `DOCS_URL=versions/main pnpm build` before/after, served locally with Playwright (no dark-mode emulation — default theme).
- [x] `getComputedStyle(el).getPropertyValue('--cds-text-primary')` inside a demo's shadow root: `''` before the fix, `#161616` after, across `button`, `tags`, and `ai-chat/truncated-text` docs pages.
- [x] Stress test on the (separately open, PR #867) `AiChatCodeSnippet`/CodeMirror demo: 26 syntax-highlighted spans collapsed to 1 flat color (`rgb(22,22,22)`) before the fix, 6 distinct theme-correct colors after.
- [x] Regression check: diffed computed `color`/`background-color`/`border-color` across ~100 elements on `button`/`tags`/`truncated-text` demos before vs. after — 0 changes, confirming already-shipped components' fallbacks already matched the real white-theme values.

🤖 Generated with [Claude Code](https://claude.com/claude-code)